### PR TITLE
Support Node.js v4 by adding 'use strict'

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const Log4js = require('log4js');
 const logger = Log4js.getLogger("generator-ibm-service-enablement");
 const Bundle = require("./../../package.json");

--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict'
 const logger = require('log4js').getLogger("generator-ibm-service-enablement:language-java");
 const Generator = require('yeoman-generator');
 const fs = require('fs');

--- a/generators/language-node-express/index.js
+++ b/generators/language-node-express/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const Log4js = require('log4js');
 const logger = Log4js.getLogger("generator-ibm-service-enablement:language-node-express");
 

--- a/generators/language-python-flask/index.js
+++ b/generators/language-python-flask/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const Log4js = require('log4js');
 const logger = Log4js.getLogger("generator-ibm-service-enablement:language-python-flask");
 

--- a/generators/language-swift-kitura/index.js
+++ b/generators/language-swift-kitura/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const logger = require('log4js').getLogger("generator-service-enablement:language-swift-kitura");
 const Generator = require('yeoman-generator');
 const handlebars = require('handlebars');

--- a/generators/service-alert-notification/index.js
+++ b/generators/service-alert-notification/index.js
@@ -1,4 +1,4 @@
-
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "alertnotification";
 const SERVICE_NAME = "service-alert-notification";

--- a/generators/service-apache-spark/index.js
+++ b/generators/service-apache-spark/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "apacheSpark";

--- a/generators/service-appid/index.js
+++ b/generators/service-appid/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "auth";

--- a/generators/service-autoscaling/index.js
+++ b/generators/service-autoscaling/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "autoscaling";

--- a/generators/service-cloudant/index.js
+++ b/generators/service-cloudant/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "cloudant";

--- a/generators/service-dashdb/index.js
+++ b/generators/service-dashdb/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 const SERVICE_NAME = "service-dashdb";
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "dashDb";

--- a/generators/service-db2/index.js
+++ b/generators/service-db2/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 const SERVICE_NAME = "service-db2";
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "db2OnCloud";

--- a/generators/service-finance-historical-instrument-analytics/index.js
+++ b/generators/service-finance-historical-instrument-analytics/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "historicalInstrumentAnalytics";

--- a/generators/service-finance-instrument-analytics/index.js
+++ b/generators/service-finance-instrument-analytics/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "instrumentAnalytics";

--- a/generators/service-finance-investment-portfolio/index.js
+++ b/generators/service-finance-investment-portfolio/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "investmentPortfolio";

--- a/generators/service-finance-portfolio-optimization/index.js
+++ b/generators/service-finance-portfolio-optimization/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "portfolioOptimization";

--- a/generators/service-finance-predictive-market-scenarios/index.js
+++ b/generators/service-finance-predictive-market-scenarios/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "predictiveMarketScenarios";

--- a/generators/service-finance-simulated-historical-instrument-analytics/index.js
+++ b/generators/service-finance-simulated-historical-instrument-analytics/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "simulatedHistoricalInstrumentAnalytics";

--- a/generators/service-finance-simulated-instrument-analytics/index.js
+++ b/generators/service-finance-simulated-instrument-analytics/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "simulatedInstrumentAnalytics";

--- a/generators/service-mongodb/index.js
+++ b/generators/service-mongodb/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "mongodb";
 const SERVICE_NAME = "service-mongodb";

--- a/generators/service-object-storage/index.js
+++ b/generators/service-object-storage/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "objectStorage";

--- a/generators/service-postgre/index.js
+++ b/generators/service-postgre/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 const localDevConfig = ['uri'];
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "postgresql";

--- a/generators/service-push/index.js
+++ b/generators/service-push/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "push";

--- a/generators/service-redis/index.js
+++ b/generators/service-redis/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "redis";

--- a/generators/service-watson-conversation/index.js
+++ b/generators/service-watson-conversation/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "conversation";

--- a/generators/service-watson-discovery/index.js
+++ b/generators/service-watson-discovery/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "discovery";

--- a/generators/service-watson-document-conversion/index.js
+++ b/generators/service-watson-document-conversion/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "documentConversion";

--- a/generators/service-watson-language-translator/index.js
+++ b/generators/service-watson-language-translator/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "languageTranslator";

--- a/generators/service-watson-natural-language-classifier/index.js
+++ b/generators/service-watson-natural-language-classifier/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "naturalLanguageClassifier";

--- a/generators/service-watson-natural-language-understanding/index.js
+++ b/generators/service-watson-natural-language-understanding/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "naturalLanguageUnderstanding";

--- a/generators/service-watson-personality-insights/index.js
+++ b/generators/service-watson-personality-insights/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "personalityInsights";

--- a/generators/service-watson-retrieve-and-rank/index.js
+++ b/generators/service-watson-retrieve-and-rank/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "retrieveAndRank";

--- a/generators/service-watson-speech-to-text/index.js
+++ b/generators/service-watson-speech-to-text/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "speechToText";

--- a/generators/service-watson-text-to-speech/index.js
+++ b/generators/service-watson-text-to-speech/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "textToSpeech";

--- a/generators/service-watson-tone-analyzer/index.js
+++ b/generators/service-watson-tone-analyzer/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "toneAnalyzer";

--- a/generators/service-watson-visual-recognition/index.js
+++ b/generators/service-watson-visual-recognition/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "visualRecognition";

--- a/generators/service-weather-company-data/index.js
+++ b/generators/service-weather-company-data/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "weatherInsights";

--- a/test/app-node-express-test.js
+++ b/test/app-node-express-test.js
@@ -1,3 +1,4 @@
+'use strict'
 const path = require('path');
 const yassert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/app-python-flask-test.js
+++ b/test/app-python-flask-test.js
@@ -1,3 +1,4 @@
+'use strict'
 const path = require('path');
 const yassert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/app-swift-kitura-test.js
+++ b/test/app-swift-kitura-test.js
@@ -1,5 +1,6 @@
 //https://github.com/yeoman/yeoman-assert
 
+'use strict'
 const path = require('path');
 const yassert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/integration-node-express-test.js
+++ b/test/integration-node-express-test.js
@@ -1,3 +1,4 @@
+'use strict'
 const optionsBluemix = Object.assign({}, require('./resources/bluemix.int.json'));
 const assert = require('chai').assert;
 const path = require('path');

--- a/test/integration-python-flask-test.js
+++ b/test/integration-python-flask-test.js
@@ -1,3 +1,4 @@
+'use strict'
 const optionsBluemix = Object.assign({}, require('./resources/bluemix.int.json'));
 const assert = require('chai').assert;
 const path = require('path');

--- a/test/lib/java-test-helpers.js
+++ b/test/lib/java-test-helpers.js
@@ -18,6 +18,7 @@
  * test helpers for java code generation
  */
 
+'use strict'
 const MAVEN_BUILD_FILE = 'pom.xml';
 const GRADLE_BUILD_FILE = 'build.gradle';
 // const SETTINGS_FILE = 'settings.gradle';

--- a/test/resources/java/index.js
+++ b/test/resources/java/index.js
@@ -1,5 +1,6 @@
 //mock generator to compose with service-enablement generator
 
+'use strict'
 const Generator = require('yeoman-generator');
 const path = require('path');
 const handlebars = require('handlebars');

--- a/test/resources/java/service-test/index.js
+++ b/test/resources/java/service-test/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const BaseGenerator = require('../../../../generators/lib/generatorbase');
 
 const SCAFFOLDER_PROJECT_PROPERTY_NAME = "test";


### PR DESCRIPTION
Needed so that generator-swiftserver does not need to drop Node.js v4 support when it starts to use generator-ibm-service-enablement.