### PR TITLE
Correct NPE in credential mapping

### DIFF
--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -87,12 +87,8 @@ module.exports = class extends Generator {
 
 	_addLocalDevConfig(devconf) {
 		logger.debug("Adding devconf", devconf);
-		if(this.context.bluemix && (this.context.bluemix.backendPlatform === 'SPRING')) {
-			let mappingsFilePath = this.destinationPath(PATH_LOCALDEV_FILE);
-			this.fs.extendJSON(mappingsFilePath, devconf);
-		} else {
-			this.context._addLocalDevConfig(devconf);
-		}
+		let localDevConfigFilePath = this.destinationPath(PATH_LOCALDEV_FILE);
+		this.fs.extendJSON(localDevConfigFilePath, devconf);
 	}
 
 	_addInstrumentation(instrumentation) {

--- a/generators/language-java/templates/java-spring/src/main/java/application/ibmcloud/CloudServices.java
+++ b/generators/language-java/templates/java-spring/src/main/java/application/ibmcloud/CloudServices.java
@@ -3,59 +3,69 @@ package application.ibmcloud;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Logger;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 
 public class CloudServices {
 
-    private static final Logger LOGGER  = LoggerFactory.getLogger(CloudServices.class);
+    private static final Logger LOGGER  = Logger.getLogger(CloudServices.class.getName());
     private static final String MAPPINGS_JSON = "/mappings.json";
     private static final String VCAP_SERVICES = "VCAP_SERVICES";
     private static final String CLASSPATH_ID = "/server/";
-    
-    
-    private JsonNode config = null; //configuration to be using
-    private final ConcurrentMap<String, DocumentContext> resourceCache = new ConcurrentHashMap<>(); //used to cache resources loaded during processing
 
+    /** Internal configuration read from MAPPINGS_JSON */
+    private JsonObject config = null;
+
+    /** used to cache resources loaded during processing */
+    private final ConcurrentMap<String, DocumentContext> resourceCache = new ConcurrentHashMap<>();
+
+    private static class SingletonHelper {
+        private static final CloudServices INSTANCE;
+        static {
+            INSTANCE = new CloudServices();
+            INSTANCE.config = INSTANCE.getJson(MAPPINGS_JSON);
+        }
+    }
+    
     /**
      * Create a cloud services mapping object from mappings.json
      * 
      * @return the configured service mapper
      */
     public static CloudServices fromMappings() {
-    	CloudServices cs = new CloudServices();
-    	cs.config = cs.getJson(MAPPINGS_JSON);
-    	return cs;
+        return SingletonHelper.INSTANCE;
     }
-    
-    private JsonNode getJson(String path) {
-        LOGGER.debug("getMappings()");
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode mappings = null;
+
+    private CloudServices() {};
+
+    private JsonObject getJson(String path) {
+        LOGGER.finest("getMappings()");
+        JsonObject mappings = null;
         try {
-        	Resource resource = new ClassPathResource(path);
-            mappings = mapper.readTree(resource.getInputStream());
-        } catch (IOException e) {
-            LOGGER.debug("Unexpected exception getting ObjectMapper for mappings.json: " + e);
+            InputStream fstream = this.getClass().getResourceAsStream(path);
+            if ( fstream != null ) {
+                mappings = Json.createReader(fstream).readObject();
+            }
+        } catch (Exception e) {
+            LOGGER.finest("Unexpected exception getting ObjectMapper for mappings.json: " + e);
             throw new CloudServicesException("Unexpected exception getting ObjectMapper for mappings.json", e);
         }
-        LOGGER.debug("getMappings() returned: " + mappings);
+        LOGGER.finest("getMappings() returned: " + mappings);
         return mappings;
     }
-    
+
     /**
      * Get the first value found from the provided searchPatterns, which will be
      * processed in the order provided.
@@ -66,32 +76,32 @@ public class CloudServices {
      * @return The value specified by the "src:target" or null if not found
      */
     public String getValue(String name) {
-    	JsonNode node = config.get(name);
-    	if(node == null || node.isNull()) {
-    		return null;		//specified name could not be located	
-    	}
+        JsonObject node = config.getJsonObject(name);
+        if(node == null || node.isEmpty()) {
+            return null;    //specified name could not be located
+        }
         String value = null;
-        ArrayNode array = (ArrayNode) node.get("searchPatterns");
-        if (array.isArray()) {
-            for (final JsonNode entryNode : array) {
-                String entry = entryNode.asText();
-                LOGGER.debug("entryNode " + entryNode);
+        JsonArray array = node.getJsonArray("searchPatterns");
+        if (array != null) {
+            for (final JsonValue entryNode : array) {
+                String entry = sanitiseString(entryNode.toString());
+                LOGGER.finest("entryNode " + entryNode);
                 String token[] = parseOnfirst(entry, ":");
-                LOGGER.debug("tokens " + token[0] + " , " + token[1]);
+                LOGGER.finest("tokens " + token[0] + " , " + token[1]);
                 if (!token[0].isEmpty() && !token[1].isEmpty()) {
                     switch (token[0]) {
-                        case "cloudfoundry":
-                            value = getCloudFoundryValue(token[1]);
-                            break;
-                        case "env":
-                            value = getEnvValue(token[1]);
-                            break;
-                        case "file":
-                            value = getFileValue(token[1]);
-                            break;
-                        default :
-                            LOGGER.warn("Unknown protocol in searchPatterns : " + token[0]);
-                            break;
+                    case "cloudfoundry":
+                        value = getCloudFoundryValue(token[1]);
+                        break;
+                    case "env":
+                        value = getEnvValue(token[1]);
+                        break;
+                    case "file":
+                        value = getFileValue(token[1]);
+                        break;
+                    default :
+                        LOGGER.warning("Unknown protocol in searchPatterns : " + token[0]);
+                        break;
                     }
                 }
                 if (value != null) {
@@ -100,7 +110,7 @@ public class CloudServices {
             }
         }
         else {
-            LOGGER.warn("search patterns in mapping.json is NOT an array, values will not be resolved");
+            LOGGER.warning("search patterns in mapping.json is NOT an array, values will not be resolved");
         }
         return value;
     }
@@ -119,10 +129,11 @@ public class CloudServices {
         String value = null;
         if (jsonPath != null && json != null) {
             value = JsonPath.parse(json).read(jsonPath);
+            value = sanitiseString(value);
         }
         return value;
     }
-    
+
     // Search pattern resolvers
     private String getCloudFoundryValue(String target) {
         if (!target.startsWith("$"))
@@ -134,13 +145,16 @@ public class CloudServices {
         String value = null;
         if (target.contains(":")) {
             String token[] = parseOnfirst(target, ":");
-            LOGGER.debug("envtokens " + token[0] + " , " + token[1]);
+            LOGGER.finest("envtokens " + token[0] + " , " + token[1]);
             if (!token[0].isEmpty() && !token[1].isEmpty() && token[1].startsWith("$") ) {
                 value = getJsonValue(token[1], System.getenv(token[0]));
             }
         }
         else {
             value = System.getenv(target);
+        }
+        if(value != null) {
+            value = sanitiseString(value);
         }
         return value;
     }
@@ -150,57 +164,57 @@ public class CloudServices {
         if (target.contains(":")) {
             String token[] = parseOnfirst(target, ":");
             if (!token[0].isEmpty() && !token[1].isEmpty() && token[1].startsWith("$") ) {
-            	String path = token[0];
-            	DocumentContext context = resourceCache.computeIfAbsent(path, filePath -> getJsonStringFromFile(filePath));
-            	value = context.read(token[1]);
+                String path = token[0];
+                DocumentContext context = resourceCache.computeIfAbsent(path, filePath -> getJsonStringFromFile(filePath));
+                value = context.read(token[1]);
             }
         }
         else {
-        	//if no location within the file has been specified then assume that the value == the first line of the file contents
+            //if no location within the file has been specified then assume that the value == the first line of the file contents
             try {
                 BufferedReader file = new BufferedReader(new FileReader(target));
                 value = file.readLine();
                 file.close();
-                LOGGER.debug("Read value from file: " + value);
+                LOGGER.finest("Read value from file: " + value);
             } catch (IOException e) {
-                LOGGER.debug("Unexpected exception reading value from file: " + e);
+                LOGGER.finest("Unexpected exception reading value from file: " + e);
             }
         }
         return value;
     }
-    
+
     //end search pattern resolvers
 
     private DocumentContext getJsonStringFromFile(String filePath) { 
         String json = null;
         if (filePath != null && !filePath.isEmpty()) {
-        	if(filePath.startsWith(CLASSPATH_ID)) {
-        		//treat file:/server as a classpath resource
-        		String path = filePath.substring(CLASSPATH_ID.length() - 1);
-        		LOGGER.debug("Looking for classpath resource : " + path);
-        		JsonNode node = getJson(path);
-        		if(node != null) {
-        			json = node.toString();
-        			LOGGER.debug("Class path json : " + json);
-        		}
-        	} else {
-        		//look for the file specified
-	            try {
-	                json = new String(Files.readAllBytes(Paths.get(filePath)));
-	            } catch (Exception e) {
-	                LOGGER.debug("Unexpected exception reading JSON string from file: " + e);
-	            }
-        	}
+            if(filePath.startsWith(CLASSPATH_ID)) {
+                //treat file:/server as a classpath resource
+                String path = filePath.substring(CLASSPATH_ID.length() - 1);
+
+                LOGGER.finest("Looking for classpath resource : " + path);
+                JsonObject node = getJson(path);
+                if(node != null) {
+                    json = node.toString();
+                    LOGGER.finest("Class path json : " + json);
+                }
+            } else {
+                //look for the file specified
+                try {
+                    json = new String(Files.readAllBytes(Paths.get(filePath)));
+                } catch (Exception e) {
+                    LOGGER.finest("Unexpected exception reading JSON string from file: " + e);
+                }
+            }
         }
         if(json == null) {
-        	return JsonPath.parse("{}");	//parse an empty object and set that for the context if the file cannot be loaded for some reason
+            return JsonPath.parse("{}");//parse an empty object and set that for the context if the file cannot be loaded for some reason
         }
         return JsonPath.parse(json);
     }
 
-    
-    @SuppressWarnings("unused")
-	private String sanitiseString(String data) throws CloudServicesException {
+
+    private String sanitiseString(String data) throws CloudServicesException {
         if (data == null || data.isEmpty()) {
             throw new CloudServicesException("Invalid string [" + data + "]");
         }

--- a/generators/language-java/templates/java-spring/src/main/java/application/ibmcloud/Mappings.java
+++ b/generators/language-java/templates/java-spring/src/main/java/application/ibmcloud/Mappings.java
@@ -6,41 +6,41 @@ import org.springframework.core.env.PropertySource;
 
 
 public class Mappings extends PropertySource<Object> {
-	private static final Logger LOGGER  = LoggerFactory.getLogger(CloudServices.class);
-	
-	private CloudServices mappings;
-	
-	public Mappings() {
-		super("CloudServices");
-		init();
-	}
-	
-	public Mappings(String name) {
-		super(name);
-		init();
-	}
+    private static final Logger LOGGER  = LoggerFactory.getLogger(CloudServices.class);
+    
+    private CloudServices mappings;
+    
+    public Mappings() {
+        super("CloudServices");
+        init();
+    }
+    
+    public Mappings(String name) {
+        super(name);
+        init();
+    }
 
-	public Mappings(String name, String source) {
-		super(name, source);
-		init();
-	}
+    public Mappings(String name, String source) {
+        super(name, source);
+        init();
+    }
 
-	private void init() {
-		try {
-			mappings = CloudServices.fromMappings();
-		} catch (CloudServicesException e) {
-			LOGGER.warn("Error reading mappings file", e);
-			mappings = null;
-		}
-	}
-	
-	@Override
-	public Object getProperty(String name) {
-		if(mappings != null) {
-			return mappings.getValue(name);
-		}
-		return null;
-	}
-	
+    private void init() {
+        try {
+            mappings = CloudServices.fromMappings();
+        } catch (CloudServicesException e) {
+            LOGGER.warn("Error reading mappings file", e);
+            mappings = null;
+        }
+    }
+    
+    @Override
+    public Object getProperty(String name) {
+        if(mappings != null) {
+            return mappings.getValue(name);
+        }
+        return null;
+    }
+    
 }
 

--- a/generators/language-java/templates/java-spring/src/main/java/application/ibmcloud/ServiceMappings.java
+++ b/generators/language-java/templates/java-spring/src/main/java/application/ibmcloud/ServiceMappings.java
@@ -17,20 +17,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class ServiceMappings {
 
-	@Autowired
-	private ConfigurableEnvironment env;
-	
-	private Mappings mappings;
-	
-	@PostConstruct
-	public void init() {
-		//registers the mapping bean as a property source so that it works with @Value
-		mappings = new Mappings("CloudServices");
-		env.getPropertySources().addFirst(mappings);
-	}
-	
-	public String getValue(String name) {
-		return (String) mappings.getProperty(name);
-	}
+    @Autowired
+    private ConfigurableEnvironment env;
+    
+    private Mappings mappings;
+    
+    @PostConstruct
+    public void init() {
+        //registers the mapping bean as a property source so that it works with @Value
+        mappings = new Mappings("CloudServices");
+        env.getPropertySources().addFirst(mappings);
+    }
+    
+    public String getValue(String name) {
+        return (String) mappings.getProperty(name);
+    }
 
 }

--- a/test/app-java-test.js
+++ b/test/app-java-test.js
@@ -65,6 +65,9 @@ class Options {
 		it('should generate mappings.json in ' + PATH_MAPPINGS_FILE, function () {
 			assert.file(PATH_MAPPINGS_FILE);
 		});
+		it('should generate ' + LOCALDEV_CONFIG_JSON, function () {
+			assert.file(LOCALDEV_CONFIG_JSON);
+		});
 	}
 
 	assertLocalDevConfig(framework, buildType, service) {
@@ -75,11 +78,9 @@ class Options {
 				value: service.localDevConfig[prop]
 			}
 			expected.envEntries.push(entry);
-			if(framework === 'spring') {
-				it('should generate a local dev entry for ' + entry.name, function() {
-					assert.fileContent(LOCALDEV_CONFIG_JSON, '"' + entry.name + '"' + ': ' + '"' + entry.value + '"');
-				});
-			}
+			it('should generate a local dev entry for ' + entry.name, function() {
+				assert.fileContent(LOCALDEV_CONFIG_JSON, '"' + entry.name + '"' + ': ' + '"' + entry.value + '"');
+			});
 		});
 	}
 
@@ -134,9 +135,6 @@ class Options {
 				assert.fileContent('src/main/java/application/bluemix/VCAPServices.java', 'import javax.json.Json;');
 			});
 		}
-		it('should not generate ' + LOCALDEV_CONFIG_JSON, function () {
-			assert.noFile(LOCALDEV_CONFIG_JSON);
-		});
 	}
 
 	assertspringenv() {
@@ -157,9 +155,6 @@ class Options {
 		});
 		it('should generate ServiceMappings.java file', function () {
 			check('src/main/java/application/ibmcloud/ServiceMappings.java');
-		});
-		it('should generate ' + LOCALDEV_CONFIG_JSON, function () {
-			assert.file(LOCALDEV_CONFIG_JSON);
 		});
 	}
 

--- a/test/resources/java/index.js
+++ b/test/resources/java/index.js
@@ -8,6 +8,7 @@ const javaGenerator = require('../../../generators/language-java/index');
 
 const optionsBluemix = Object.assign({}, require('../bluemix.json'));
 const PATH_MAPPINGS_FILE = "./src/main/resources/mappings.json";
+const PATH_LOCALDEV_FILE = "./src/main/resources/localdev-config.json";
 
 module.exports = class extends Generator {
 	constructor(args, opts) {
@@ -73,6 +74,8 @@ module.exports = class extends Generator {
       });
     }
     this.conf.envEntries = this.conf.envEntries.concat(entries);
+		let localDevConfigFilePath = this.destinationPath(PATH_LOCALDEV_FILE);
+		this.fs.extendJSON(localDevConfigFilePath, devconf);
   }
 
   _addMappings(serviceMappingsJSON) {


### PR DESCRIPTION
Singleton constructor to read mappings.json file once
Do not attempt to parse json if input stream can't exist (shows better error than NPE).
Adjust tests -- local-config.json should always be present

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>