### PR TITLE
fix: async completion and error propagation

### DIFF
--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -131,6 +131,6 @@ module.exports = class extends Generator {
 
 	end() {
 		// add services env to deployment.yaml
-		Utils.addServicesEnvToDeploymentYaml({context: this.context, destinationPath: this.destinationPath()});
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
 	}
 }

--- a/generators/language-node-express/index.js
+++ b/generators/language-node-express/index.js
@@ -143,6 +143,6 @@ module.exports = class extends Generator {
 		}
 
 		// add services env to deployment.yaml
-		Utils.addServicesEnvToDeploymentYaml({context: this.context, destinationPath: this.destinationPath()});
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
 	}
 };

--- a/generators/language-python-flask/index.js
+++ b/generators/language-python-flask/index.js
@@ -166,6 +166,6 @@ module.exports = class extends Generator {
 		}
 
 		// add services env to deployment.yaml
-		Utils.addServicesEnvToDeploymentYaml({context: this.context, destinationPath: this.destinationPath()});
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
 	}
 };

--- a/generators/language-swift-kitura/index.js
+++ b/generators/language-swift-kitura/index.js
@@ -227,6 +227,6 @@ module.exports = class extends Generator {
 
 	end() {
 		// add services env to deployment.yaml
-		Utils.addServicesEnvToDeploymentYaml({context: this.context, destinationPath: this.destinationPath()});
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
 	}
 };

--- a/test/app-node-express-test.js
+++ b/test/app-node-express-test.js
@@ -13,9 +13,9 @@ const SERVER_LOCALDEV_CONFIG_JSON = 'server/localdev-config.json';
 describe('node-express', function () {
 	this.timeout(10 * 1000); // 10 seconds, Travis might be slow
 
-	before((done) => {
+	before(() => {
 		optionsBluemix.backendPlatform = "NODE";
-		helpers
+		return helpers
 			.run(path.join(__dirname, GENERATOR_PATH))
 			.inTmpDir()
 			.withOptions({
@@ -23,7 +23,6 @@ describe('node-express', function () {
 			})
 			.then((tmpDir) => {
 				console.info("tmpDir", tmpDir);
-				done();
 			});
 	});
 

--- a/test/app-python-flask-test.js
+++ b/test/app-python-flask-test.js
@@ -13,9 +13,9 @@ const SERVER_LOCALDEV_CONFIG_JSON = 'server/localdev-config.json';
 describe('python-flask', function () {
 	this.timeout(10 * 1000); // 10 seconds, Travis might be slow
 
-	before((done) => {
+	before(() => {
 		optionsBluemix.backendPlatform = "PYTHON";
-		helpers
+		return helpers
 			.run(path.join(__dirname, GENERATOR_PATH))
 			.inTmpDir()
 			.withOptions({
@@ -23,7 +23,6 @@ describe('python-flask', function () {
 			})
 			.then((tmpDir) => {
 				console.info(tmpDir);
-				done();
 			});
 	});
 

--- a/test/app-services-with-deployment-test.js
+++ b/test/app-services-with-deployment-test.js
@@ -17,7 +17,7 @@ const DEPLOYMENT_FILE_PATH =  `/chart/${APP_NAME}/templates/deployment.yaml`;
 describe('app-services-with-deployment', function () {
 	this.timeout(10 * 1000); // 10 seconds, Travis might be slow
 
-	before((done) => {
+	before(() => {
 		let context = {};
 		context.bluemix = JSON.parse(JSON.stringify(optionsBluemix));
 		context.loggerLevel = logger.level;
@@ -26,7 +26,7 @@ describe('app-services-with-deployment', function () {
 		context.bluemix.backendPlatform = 'NODE';
 		context.language = context.bluemix.backendPlatform.toLowerCase();
 
-		helpers
+		return helpers
 			.run(path.join(__dirname, GENERATOR_NODE_PATH))
 			.inTmpDir((dir) => {
 				// `dir` is the path to the new temporary directory
@@ -41,7 +41,6 @@ describe('app-services-with-deployment', function () {
 			})
 			.then((tmpDir) => {
 				console.info("tmpDir", tmpDir);
-				done();
 			});
 	});
 


### PR DESCRIPTION
Yeoman was not being properly notified that async work was being performed causing it to consider a generator finished despite some file IO not yet being completed. This caused test failures and would possibly cause issues when running yeoman as an embedded library (as YaaS does).

I tried fixing just using callbacks, but proper error handling was cumbersome, so I have used (native) Promises instead. Testing revealed a few places in test files where the promise chain was not being properly respected (manifesting as UnhandledPromiseRejections), so I also fixed those in this PR to ensure tests fail gracefully.