### PR TITLE
feat: add cloudant create-service to pipeline.yml

### DIFF
--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -130,7 +130,7 @@ module.exports = class extends Generator {
 	}
 
 	end() {
-		// add services env to deployment.yaml
-		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
+		// add services env to deployment.yaml && cf create-service to pipeline.yaml
+		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
 	}
 }

--- a/generators/language-node-express/index.js
+++ b/generators/language-node-express/index.js
@@ -142,7 +142,7 @@ module.exports = class extends Generator {
 			this.fs.write(gitIgnorePath, PATH_LOCALDEV_CONFIG_FILE);
 		}
 
-		// add services env to deployment.yaml
-		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
+		// add services env to deployment.yaml && cf create-service to pipeline.yaml
+		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
 	}
 };

--- a/generators/language-python-flask/index.js
+++ b/generators/language-python-flask/index.js
@@ -291,7 +291,6 @@ module.exports = class extends Generator {
 		}
 
 		this.fs.move(this.destinationPath() + '/Pipfile.txt', this.destinationPath() + '/Pipfile', {nodir: true});
-		// add services env to deployment.yaml
-		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
+		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
 	}
 };

--- a/generators/language-swift-kitura/index.js
+++ b/generators/language-swift-kitura/index.js
@@ -244,7 +244,7 @@ module.exports = class extends Generator {
 	}
 
 	end() {
-		// add services env to deployment.yaml
-		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()});
+		// add services env to deployment.yaml && cf create-service to pipeline.yaml
+		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
 	}
 };

--- a/generators/lib/Utils.js
+++ b/generators/lib/Utils.js
@@ -5,105 +5,177 @@ const readline = require('readline');
 const fs = require('fs');
 
 const REGEX_ENV = /env:/;
+const REGEX_DEPLOY = /- name: Deploy Stage/;
+const REGEX_KUBE	= /kubernetes_cluster:/;
+const REGEX_BASH = /#!\/bin\/bash/;
 
-module.exports = {
 
-	addServicesEnvToDeploymentYamlAsync(args) {
-		return new Promise((resolve, reject) => {
-			let context = args.context;
-			let destinationPath = args.destinationPath;
+function addServicesEnvToDeploymentYamlAsync(args) {
+	return new Promise((resolve, reject) => {
+		let context = args.context;
+		let destinationPath = args.destinationPath;
 
-			let hasServices = context.deploymentServicesEnv && context.deploymentServicesEnv.length > 0;
-			if (!hasServices) {
-				logger.info('No services to add to deployment.yaml');
-				return resolve();
-			}
+		let hasServices = context.deploymentServicesEnv && context.deploymentServicesEnv.length > 0;
+		if (!hasServices) {
+			logger.info('No services to add to deployment.yaml');
+			return resolve();
+		}
 
-			// this deployment.yaml file should've been generated in the generator-ibm-cloud-enablement generator
-			// for deploy to Kubernetes using Helm chart
-			let chartFolderPath = `${destinationPath}/chart`;
-			if (!fs.existsSync(chartFolderPath)) {
-				logger.info('/chart folder does not exist');
-				return resolve();
-			}
+		// this deployment.yaml file should've been generated in the generator-ibm-cloud-enablement generator
+		// for deploy to Kubernetes using Helm chart
+		let chartFolderPath = `${destinationPath}/chart`;
+		if (!fs.existsSync(chartFolderPath)) {
+			logger.info('/chart folder does not exist');
+			return resolve();
+		}
 
-			let deploymentFilePath = `${chartFolderPath}/${context.sanitizedAppName}/templates/deployment.yaml`;
-			logger.info(`deployment.yaml path: ${deploymentFilePath}`);
+		let deploymentFilePath = `${chartFolderPath}/${context.sanitizedAppName}/templates/deployment.yaml`;
+		logger.info(`deployment.yaml path: ${deploymentFilePath}`);
 
-			let deploymentFileExists = fs.existsSync(deploymentFilePath);
-			if (!deploymentFileExists) {
-				logger.info(`deployment.yaml does not exist at ${deploymentFilePath}, checking /chart directory`);
-				// chart could've been created with different name than expected
-				let chartFolders = fs.readdirSync(`${chartFolderPath}`);
-				// there should only be one folder under /chart, but just in case
-				for (let i = 0; i < chartFolders.length; i++) {
-					deploymentFilePath = `${chartFolderPath}/${chartFolders[i]}/templates/deployment.yaml`;
-					deploymentFileExists = fs.existsSync(deploymentFilePath);
-					if (deploymentFileExists) {
-						logger.info(`found deployment.yaml file at ${deploymentFilePath}`);
-						break;
-					}
+		let deploymentFileExists = fs.existsSync(deploymentFilePath);
+		if (!deploymentFileExists) {
+			logger.info(`deployment.yaml does not exist at ${deploymentFilePath}, checking /chart directory`);
+			// chart could've been created with different name than expected
+			let chartFolders = fs.readdirSync(`${chartFolderPath}`);
+			// there should only be one folder under /chart, but just in case
+			for (let i = 0; i < chartFolders.length; i++) {
+				deploymentFilePath = `${chartFolderPath}/${chartFolders[i]}/templates/deployment.yaml`;
+				deploymentFileExists = fs.existsSync(deploymentFilePath);
+				if (deploymentFileExists) {
+					logger.info(`found deployment.yaml file at ${deploymentFilePath}`);
+					break;
 				}
 			}
+		}
 
-			if (!deploymentFileExists) {
-				logger.error('deployment.yaml not found, cannot add services to env');
-				return resolve();
-			}
+		if (!deploymentFileExists) {
+			logger.error('deployment.yaml not found, cannot add services to env');
+			return resolve();
+		}
 
-			logger.info(`deployment.yaml exists, adding ${context.deploymentServicesEnv.length} to env` );
+		logger.info(`deployment.yaml exists, adding ${context.deploymentServicesEnv.length} to env` );
 
-			let readStream = fs.createReadStream(deploymentFilePath);
-			let promiseIsRejected = false;
-			readStream.on('error', (err) => {
-				logger.error('failed to read deployment.yaml from filesystem: ' + err.message);
-				reject(err);
-				promiseIsRejected = true;
-			});
-			let rl = readline.createInterface({ input: readStream });
+		let readStream = fs.createReadStream(deploymentFilePath);
+		let promiseIsRejected = false;
+		readStream.on('error', (err) => {
+			logger.error('failed to read deployment.yaml from filesystem: ' + err.message);
+			reject(err);
+			promiseIsRejected = true;
+		});
+		let rl = readline.createInterface({ input: readStream });
 
-			let deploymentFileString = '';
-			rl.on('line', (line) => {
-				deploymentFileString += `${line}\n`;
+		let deploymentFileString = '';
+		rl.on('line', (line) => {
+			deploymentFileString += `${line}\n`;
 
-				let envIndex = line.search(REGEX_ENV);
-				if (envIndex > -1) {
-					logger.info(`deployment.yaml env section index: ${envIndex}`);
+			let envIndex = line.search(REGEX_ENV);
+			if (envIndex > -1) {
+				logger.info(`deployment.yaml env section index: ${envIndex}`);
 
-					let spacesPrefix = line.slice(0, envIndex);
+				let spacesPrefix = line.slice(0, envIndex);
 
-					// TODO: more robust check of spaces to prefix
-					// valid to have items under env: section be at same level or indented by two spaces
-					// env:
-					// - name: service_watson_tone_analyzer
-					// also valid to have this ->
-					// env:
-					//   - name: service_watson_tone_analyzer
-					// so check if env: section already has items under it, if so, use same amount of spaces as existing items
+				// TODO: more robust check of spaces to prefix
+				// valid to have items under env: section be at same level or indented by two spaces
+				// env:
+				// - name: service_watson_tone_analyzer
+				// also valid to have this ->
+				// env:
+				//	 - name: service_watson_tone_analyzer
+				// so check if env: section already has items under it, if so, use same amount of spaces as existing items
 
-					let servicesEnvString = '';
-					context.deploymentServicesEnv.forEach((serviceEntry) => {
-						servicesEnvString +=
-							`${spacesPrefix}  - name: ${serviceEntry.name}\n` +
-							`${spacesPrefix}    valueFrom:\n` +
-							`${spacesPrefix}      secretKeyRef:\n` +
-							`${spacesPrefix}        name: ${serviceEntry.valueFrom.secretKeyRef.name}\n` +
-							`${spacesPrefix}        key: ${serviceEntry.valueFrom.secretKeyRef.key}\n`;
-					});
-					deploymentFileString += servicesEnvString;
-				}
-			}).on('close', () => {
-				if (promiseIsRejected) { return; }
-				fs.writeFile(deploymentFilePath, deploymentFileString, (err) => {
-					if (err) {
-						logger.error('failed to write updated deployment.yaml to filesystem: ' + err.message);
-						reject(err);
-					} else {
-						logger.info('finished updating deployment.yaml and wrote to filesystem');
-						resolve();
-					}
+				let servicesEnvString = '';
+				context.deploymentServicesEnv.forEach((serviceEntry) => {
+					servicesEnvString +=
+						`${spacesPrefix}  - name: ${serviceEntry.name}\n` +
+						`${spacesPrefix}    valueFrom:\n` +
+						`${spacesPrefix}      secretKeyRef:\n` +
+						`${spacesPrefix}        name: ${serviceEntry.valueFrom.secretKeyRef.name}\n` +
+						`${spacesPrefix}        key: ${serviceEntry.valueFrom.secretKeyRef.key}\n`;
 				});
+				deploymentFileString += servicesEnvString;
+			}
+		}).on('close', () => {
+			if (promiseIsRejected) { return; }
+			fs.writeFile(deploymentFilePath, deploymentFileString, (err) => {
+				if (err) {
+					logger.error('failed to write updated deployment.yaml to filesystem: ' + err.message);
+					reject(err);
+				} else {
+					logger.info('finished updating deployment.yaml and wrote to filesystem');
+					resolve();
+				}
 			});
 		});
-	}
+	});
+}
+
+function addServicesToPipelineYamlAsync(args) {
+	return new Promise((resolve,reject) => {
+		let context = args.context;
+		let destinationPath = args.destinationPath;
+
+		// this pipeline.yaml file should've been generated in the generator-ibm-cloud-enablement generator
+		// for deploy to Kubernetes using Helm chart
+		let pipelineFilePath = `${destinationPath}/.bluemix/pipeline.yml`;
+		logger.info(`pipeline.yml path: ${pipelineFilePath}`);
+
+		let pipelineFileExists = fs.existsSync(pipelineFilePath);
+		if (!pipelineFileExists) { return resolve(); }
+		logger.info("pipeline.yml exists, setting cf create-service for services");
+
+		let hasServices = context.servicesInfo && context.servicesInfo.length > 0;
+		if (!hasServices) { return resolve(); }
+		logger.info(`has ${context.deploymentServicesEnv.length} services, adding to pipeline.yaml deploy`);
+		let readStream = fs.createReadStream(pipelineFilePath);
+		let promiseIsRejected = false;
+		readStream.on('error', (err) => {
+			logger.error('failed to read pipeline.yml from filesystem: ' + err.message);
+			reject(err);
+			promiseIsRejected = true;
+		});
+		let rl = readline.createInterface({ input: readStream });
+		let pipelineFileString = '';
+		let deployBool = false;
+		let kubeBool = false;
+		rl.on('line', (line) => {
+			pipelineFileString += `${line}\n`;
+
+			let deployIndex = line.search(REGEX_DEPLOY);
+			if(deployIndex > -1){deployBool = true;}
+
+			let kubeIndex = line.search(REGEX_KUBE);
+			if(kubeIndex > -1){kubeBool = true;}
+
+			let bashIndex = line.search(REGEX_BASH);
+			if (bashIndex > -1 && deployBool) {
+				if(kubeBool){
+					kubeBool = false;
+				}
+				else{
+					logger.info(`pipeline.yaml cf section index: ${bashIndex}`);
+					let spacesPrefix = line.slice(0, bashIndex);
+					context.servicesInfo.forEach( function(service) {
+						pipelineFileString += spacesPrefix + "cf create-service " + service.label + " " + service.plan + " " + service.name + "\n";
+					})
+				}
+			}
+		}).on('close', () => {
+			if (promiseIsRejected) { return; }
+			fs.writeFile(pipelineFilePath, pipelineFileString, (err) => {
+				if (err) {
+					logger.error('failed to write updated pipeline.yaml to filesystem: ' + err.message);
+					reject(err);
+				} else {
+					logger.info('finished updating pipeline.yaml and wrote to filesystem');
+					resolve();
+				}
+			});
+		});
+	})
+}
+
+
+module.exports = {
+	addServicesEnvToDeploymentYamlAsync: addServicesEnvToDeploymentYamlAsync,
+	addServicesToPipelineYamlAsync: addServicesToPipelineYamlAsync
 };

--- a/generators/lib/generatorbase.js
+++ b/generators/lib/generatorbase.js
@@ -51,7 +51,12 @@ module.exports = class extends Generator {
 		this._addLocalDevConfig();
 		this._addReadMe();
 		this._addInstrumentation();
-		this._addServicesToKubeDeploy();
+
+		let serviceInfo = this._getServiceInfo();
+		if(serviceInfo !== undefined ){
+			this._addServicesToKubeDeploy(serviceInfo);
+			this._addServicesToPipeline(serviceInfo);
+		}
 	}
 
 	writing() {
@@ -64,9 +69,7 @@ module.exports = class extends Generator {
 		return name;
 	}
 
-	_addServicesToKubeDeploy() {
-		this.logger.info(`adding Deployment service env info for ${this.serviceName}`);
-
+	_getServiceInfo(){
 		let serviceInfo = {};
 		if (this.context.bluemix[this.scaffolderName]) {
 			let service = this.context.bluemix[this.scaffolderName];
@@ -76,6 +79,17 @@ module.exports = class extends Generator {
 				serviceInfo = service.serviceInfo;
 			}
 		}
+		return serviceInfo;
+	}
+	_addServicesToPipeline(serviceInfo){
+		if(!this.context.servicesInfo){
+			this.context.servicesInfo = [];
+		}
+		this.context.servicesInfo.push(serviceInfo);
+	}
+
+	_addServicesToKubeDeploy(serviceInfo) {
+		this.logger.info(`adding Deployment service env info for ${this.serviceName}`);
 
 		let serviceEnv = {
 			name: this._sanitizeServiceName(this.serviceName),

--- a/test/app-services-with-pipeline-test.js
+++ b/test/app-services-with-pipeline-test.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const yassert = require('yeoman-assert');
+const assert = require('assert');
+const helpers = require('yeoman-test');
+const Log4js = require('log4js');
+const logger = Log4js.getLogger("generator-ibm-service-enablement:app-generatorbase-test");
+const fs = require('fs');
+const optionsBluemix = Object.assign({}, require('./resources/bluemix.json'));
+
+const GENERATOR_NODE_PATH = '../generators/language-node-express/index.js';
+
+const RESOURCES_PATH = path.join(__dirname, './resources');
+const PIPELINE_FILE_PATH =	`.bluemix/pipeline.yml`;
+
+describe('app-services-with-pipeline', function () {
+	this.timeout(10 * 1000); // 10 seconds, Travis might be slow
+	before(() => {
+		let context = {};
+		context.bluemix = JSON.parse(JSON.stringify(optionsBluemix));
+		context.loggerLevel = logger.level;
+		context.sanitizedAppName = context.bluemix.name.toLowerCase();
+
+		context.bluemix.backendPlatform = 'NODE';
+		context.language = context.bluemix.backendPlatform.toLowerCase();
+
+		return helpers
+			.run(path.join(__dirname, GENERATOR_NODE_PATH))
+			.inTmpDir((dir) => {
+				// `dir` is the path to the new temporary directory
+				let pipelineFile = fs.readFileSync(path.join(RESOURCES_PATH, `/pipeline.yml`));
+				fs.mkdirSync(path.join(dir, `/.bluemix`));
+				fs.writeFileSync(path.join(dir, PIPELINE_FILE_PATH), pipelineFile);
+			})
+			.withOptions({
+				context: context
+			})
+			.then((tmpDir) => {
+				console.info("tmpDir", tmpDir);
+			});
+	});
+
+	it('appended cf create-service for each service to pipeline.yaml', () => {
+		let generatedFilePath = path.join('.', PIPELINE_FILE_PATH);
+		yassert.file(generatedFilePath);
+
+		let expected = fs.readFileSync(path.join(RESOURCES_PATH, `/pipeline-result-node.yml`), 'utf-8');
+		let actual = fs.readFileSync(generatedFilePath, 'utf-8');
+		if(actual !== '' ) {
+			assert.equal(actual, expected);
+		}
+	});
+
+});

--- a/test/resources/pipeline-result-node.yml
+++ b/test/resources/pipeline-result-node.yml
@@ -1,0 +1,126 @@
+stages:
+- name: Build Stage
+  inputs:
+  - type: git
+    branch: master
+    service: ${REPO}
+{{#if config.triggersType}}
+  triggers:
+    - type: {{config.triggersType}}
+{{/if}}
+  jobs:
+  - name: Build
+    type: builder
+    {{#missing deployment.type 'Kube'}}
+    {{#each config.buildJobProps}}
+    {{@key}}: {{{this}}}
+    {{/each}}
+    {{/missing}}
+    {{#has deployment.type 'Kube'}}
+    extension_id: ibm.devops.services.pipeline.container.builder
+    target:
+      region_id: ${CF_REGION_ID}
+      organization: ${CF_ORGANIZATION}
+      space: ${CF_SPACE}
+    IMAGE_NAME: {{deployment.name}}
+    USE_CACHED_LAYERS: 'true'
+    COMMAND: |
+      #!/bin/bash
+      {{#if config.javaBuildScriptContent}}
+      echo "Doing Java build..."
+      {{{config.javaBuildScriptContent}}}
+      {{/if}}
+      echo "source the container_build script to run in current shell"
+      source {{{deployment.containerScriptPath}}}
+    {{/has}}
+  - name: Post Build
+    type: builder
+    artifact_dir: ''
+    build_type: shell
+    script: |-
+      #!/bin/bash
+      if  [[ -f post_build.sh ]]; then
+        chmod +x post_build.sh;
+        echo "executing the post_build script";
+        sh post_build.sh;
+      else
+        echo "the post_build script does not exist";
+      fi
+- name: Deploy Stage
+  inputs:
+  - type: job
+    stage: Build Stage
+    job: Build
+  {{#has deployment.type 'Kube'}}
+  properties:
+  - name: buildProperties
+    value: build.properties
+    type: file
+  - name: CLUSTER_NAMESPACE
+    value: {{deployment.kubeClusterNamespace}}
+    type: text
+  - name: IMAGE_PULL_SECRET_NAME
+    value: ${IMAGE_PULL_SECRET_NAME}
+    type: text
+  - name: IMAGE_REGISTRY_TOKEN
+    value: ${IMAGE_REGISTRY_TOKEN}
+    type: text
+  {{/has}}
+  triggers:
+  - type: stage
+  jobs:
+  - name: Deploy
+    type: deployer
+    target:
+      region_id: ${CF_REGION_ID}
+      organization: ${CF_ORGANIZATION}
+      space: ${CF_SPACE}
+      application: ${CF_APP}
+    {{#has deployment.type 'Kube'}}
+      api_key: ${API_KEY}
+      kubernetes_cluster: ${KUBE_CLUSTER_NAME}
+    script: |-
+      #!/bin/bash
+      echo "source the kube_deploy script to run in current shell"
+      source {{{deployment.kubeDeployScriptName}}}
+    {{/has}}
+    {{#has deployment.type 'CF'}}
+    script: |-
+      #!/bin/bash
+      cf create-service auth-label auth-plan auth-name
+      cf create-service cloudant-label cloudant-plan cloudant-name
+      cf create-service spark ibm.SparkService.PayGoPersonal apache-spark-name
+      cf create-service dashDB Entry dashdb-name
+      cf create-service db2 Entry db2-name
+      cf create-service object-storage-label object-storage-plan object-storage-name
+      cf create-service conversation-label conversation-plan conversation-name
+      cf create-service discovery-label discovery-plan discovery-name
+      cf create-service document-conversion-label document-conversion-plan document-conversion-name
+      cf create-service language-translator-label language-translator-plan language-translator-name
+      cf create-service natural-language-classifier-label natural-language-classifier-plan natural-language-classifier-name
+      cf create-service natural-language-understanding-label natural-language-understanding-plan natural-language-understanding-name
+      cf create-service personality-insights-label personality-insights-plan personality-insights-name
+      cf create-service retrieve-and-rank-label retrieve-and-rank-plan retrieve-and-rank-name
+      cf create-service speech-to-text-label speech-to-text-plan speech-to-text-name
+      cf create-service text-to-speech-label text-to-speech-plan text-to-speech-name
+      cf create-service tone-analyzer-label tone-analyzer-plan tone-analyzer-name
+      cf create-service visual-recognition-label visual-recognition-plan visual-recognition-name
+      cf create-service fss-instrument-analytics-service fss-instrument-analytics-service-free-plan instrument-analytics-label
+      cf create-service fss-scenario-analytics-service fss-scenario-analytics-service-free-plan simulated-instrument-analytics-name
+      cf create-service fss-historical-instrument-analytics-service fss-historical-instrument-analytics-service-free-plan historical-instrument-analytics-name
+      cf create-service fss-historical-scenario-analytics-service fss-historical-scenario-analytics-service-free-plan simulated-historical-instrument-analytics-name
+      cf create-service fss-portfolio-service fss-portfolio-service-free-plan investment-portfolio-name
+      cf create-service fss-predictive-scenario-analytics-service fss-predictive-scenario-analytics-service-free-plan predictive-market-scenarios-name
+      cf create-service weather-insights-label weather-insights-plan weather-insights-name
+      cf create-service mongodb-label mongodb-plan mongodb-name
+      cf create-service compose-for-redis redis-plan redis-name
+      cf create-service postgresql-label postgresql-plan postgresql-name
+      cf create-service push-label push-plan push-name
+      cf create-service alert-notifcation-label alert-notifcation-plan alert-notifcation-name
+      {{#if config.pushCommand}}
+      {{{config.pushCommand}}}
+      {{else}}
+      cf push "${CF_APP}"
+      {{/if}}
+      # cf logs "${CF_APP}" --recent
+    {{/has}}

--- a/test/resources/pipeline.yml
+++ b/test/resources/pipeline.yml
@@ -1,0 +1,96 @@
+stages:
+- name: Build Stage
+  inputs:
+  - type: git
+    branch: master
+    service: ${REPO}
+{{#if config.triggersType}}
+  triggers:
+    - type: {{config.triggersType}}
+{{/if}}
+  jobs:
+  - name: Build
+    type: builder
+    {{#missing deployment.type 'Kube'}}
+    {{#each config.buildJobProps}}
+    {{@key}}: {{{this}}}
+    {{/each}}
+    {{/missing}}
+    {{#has deployment.type 'Kube'}}
+    extension_id: ibm.devops.services.pipeline.container.builder
+    target:
+      region_id: ${CF_REGION_ID}
+      organization: ${CF_ORGANIZATION}
+      space: ${CF_SPACE}
+    IMAGE_NAME: {{deployment.name}}
+    USE_CACHED_LAYERS: 'true'
+    COMMAND: |
+      #!/bin/bash
+      {{#if config.javaBuildScriptContent}}
+      echo "Doing Java build..."
+      {{{config.javaBuildScriptContent}}}
+      {{/if}}
+      echo "source the container_build script to run in current shell"
+      source {{{deployment.containerScriptPath}}}
+    {{/has}}
+  - name: Post Build
+    type: builder
+    artifact_dir: ''
+    build_type: shell
+    script: |-
+      #!/bin/bash
+      if  [[ -f post_build.sh ]]; then
+        chmod +x post_build.sh;
+        echo "executing the post_build script";
+        sh post_build.sh;
+      else
+        echo "the post_build script does not exist";
+      fi
+- name: Deploy Stage
+  inputs:
+  - type: job
+    stage: Build Stage
+    job: Build
+  {{#has deployment.type 'Kube'}}
+  properties:
+  - name: buildProperties
+    value: build.properties
+    type: file
+  - name: CLUSTER_NAMESPACE
+    value: {{deployment.kubeClusterNamespace}}
+    type: text
+  - name: IMAGE_PULL_SECRET_NAME
+    value: ${IMAGE_PULL_SECRET_NAME}
+    type: text
+  - name: IMAGE_REGISTRY_TOKEN
+    value: ${IMAGE_REGISTRY_TOKEN}
+    type: text
+  {{/has}}
+  triggers:
+  - type: stage
+  jobs:
+  - name: Deploy
+    type: deployer
+    target:
+      region_id: ${CF_REGION_ID}
+      organization: ${CF_ORGANIZATION}
+      space: ${CF_SPACE}
+      application: ${CF_APP}
+    {{#has deployment.type 'Kube'}}
+      api_key: ${API_KEY}
+      kubernetes_cluster: ${KUBE_CLUSTER_NAME}
+    script: |-
+      #!/bin/bash
+      echo "source the kube_deploy script to run in current shell"
+      source {{{deployment.kubeDeployScriptName}}}
+    {{/has}}
+    {{#has deployment.type 'CF'}}
+    script: |-
+      #!/bin/bash
+      {{#if config.pushCommand}}
+      {{{config.pushCommand}}}
+      {{else}}
+      cf push "${CF_APP}"
+      {{/if}}
+      # cf logs "${CF_APP}" --recent
+    {{/has}}


### PR DESCRIPTION
[Issue #333](https://github.ibm.com/arf/planning-swift-solutions/issues/333)
Extracting services information from payload and injecting cf create-service into pipeline.yml for all languages.
Created corresponding tests. 
- [X] `npm test`
- `npm run integration` fails 