### PR TITLE
fix: remove race from incorrectly chained promises

### DIFF
--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -159,6 +159,7 @@ module.exports = class extends Generator {
 
 	end() {
 		// add services env to deployment.yaml && cf create-service to pipeline.yaml
-		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()})
+			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 }

--- a/generators/language-node-express/index.js
+++ b/generators/language-node-express/index.js
@@ -143,6 +143,7 @@ module.exports = class extends Generator {
 		}
 
 		// add services env to deployment.yaml && cf create-service to pipeline.yaml
-		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()})
+			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 };

--- a/generators/language-python-flask/index.js
+++ b/generators/language-python-flask/index.js
@@ -291,6 +291,7 @@ module.exports = class extends Generator {
 		}
 
 		this.fs.move(this.destinationPath() + '/Pipfile.txt', this.destinationPath() + '/Pipfile', {nodir: true});
-		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()})
+			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 };

--- a/generators/language-swift-kitura/index.js
+++ b/generators/language-swift-kitura/index.js
@@ -245,6 +245,7 @@ module.exports = class extends Generator {
 
 	end() {
 		// add services env to deployment.yaml && cf create-service to pipeline.yaml
-		return [ Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()}) , Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()})];
+		return Utils.addServicesEnvToDeploymentYamlAsync({context: this.context, destinationPath: this.destinationPath()})
+			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 };


### PR DESCRIPTION
This fixes an intermittent problem with UnhandledPromiseRejection and/or the `pipeline.yml` file not being updated before tests complete.

Returning an array of promises to Yeoman does not ensure the promises are resolved before it declares the action complete. Therefore they sometimes complete in time and sometimes don't. Also any errors are not transferred up the promise chain (since the promises are not part of the chain).

Instead we need to construct a single Promise to return that Yeoman will wait for. Since both async functions are writing to the same file, it made sense to have them execute serially rather than in parallel, so I have opted for using `.then()` to chain them (instead of using `Promise.all()`).