### PR TITLE
fix: updated Watson Developer Cloud version from 0.26 to 1.0.2

### DIFF
--- a/generators/service-watson-conversation/templates/python/Pipfile.json
+++ b/generators/service-watson-conversation/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-conversation/templates/python/README.md
+++ b/generators/service-watson-conversation/templates/python/README.md
@@ -40,7 +40,7 @@ workspace_id = 'bdce14dd-65ce-4e50-91b9-dea4d7445393'
 # Add new data to the collection
 @app.route('/sendMessage/<string:message>')
 def sendMessage(message):
-	response = conversation.message(workspace_id=workspace_id, message_input={
+	response = conversation.message(workspace_id=workspace_id, input={
 		'text': message
 	})
 

--- a/generators/service-watson-conversation/templates/python/requirements.txt
+++ b/generators/service-watson-conversation/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-discovery/templates/python/Pipfile.json
+++ b/generators/service-watson-discovery/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-discovery/templates/python/requirements.txt
+++ b/generators/service-watson-discovery/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-document-conversion/templates/python/Pipfile.json
+++ b/generators/service-watson-document-conversion/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-document-conversion/templates/python/requirements.txt
+++ b/generators/service-watson-document-conversion/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-language-translator/templates/python/Pipfile.json
+++ b/generators/service-watson-language-translator/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-language-translator/templates/python/requirements.txt
+++ b/generators/service-watson-language-translator/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-natural-language-classifier/templates/python/Pipfile.json
+++ b/generators/service-watson-natural-language-classifier/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-natural-language-classifier/templates/python/requirements.txt
+++ b/generators/service-watson-natural-language-classifier/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-natural-language-understanding/templates/python/Pipfile.json
+++ b/generators/service-watson-natural-language-understanding/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-natural-language-understanding/templates/python/requirements.txt
+++ b/generators/service-watson-natural-language-understanding/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-personality-insights/templates/python/Pipfile.json
+++ b/generators/service-watson-personality-insights/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-personality-insights/templates/python/requirements.txt
+++ b/generators/service-watson-personality-insights/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-retrieve-and-rank/templates/python/Pipfile.json
+++ b/generators/service-watson-retrieve-and-rank/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-retrieve-and-rank/templates/python/requirements.txt
+++ b/generators/service-watson-retrieve-and-rank/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-speech-to-text/templates/python/Pipfile.json
+++ b/generators/service-watson-speech-to-text/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-speech-to-text/templates/python/requirements.txt
+++ b/generators/service-watson-speech-to-text/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-text-to-speech/templates/python/Pipfile.json
+++ b/generators/service-watson-text-to-speech/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-text-to-speech/templates/python/requirements.txt
+++ b/generators/service-watson-text-to-speech/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-tone-analyzer/templates/python/Pipfile.json
+++ b/generators/service-watson-tone-analyzer/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-tone-analyzer/templates/python/requirements.txt
+++ b/generators/service-watson-tone-analyzer/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2

--- a/generators/service-watson-visual-recognition/templates/python/Pipfile.json
+++ b/generators/service-watson-visual-recognition/templates/python/Pipfile.json
@@ -2,6 +2,6 @@
   "[[source]]": "",
   "[dev-packages]": "",
   "[packages]": {
-    "watson-developer-cloud": "~=0.26"
+    "watson-developer-cloud": "~=1.0.2"
   }
 }

--- a/generators/service-watson-visual-recognition/templates/python/requirements.txt
+++ b/generators/service-watson-visual-recognition/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-watson-developer-cloud~=0.26
+watson-developer-cloud~=1.0.2


### PR DESCRIPTION
Watson Developer Cloud has updated method and parameter names but we aren't using any of those when adding a service to a project. Also, updated a Readme that had an example of one of the method changes made