### PR TITLE
fix: swift services fail on kubernetes

### DIFF
--- a/generators/language-swift-kitura/index.js
+++ b/generators/language-swift-kitura/index.js
@@ -73,6 +73,9 @@ module.exports = class extends Generator {
 	}
 
 	_addMappings(serviceMappingsJSON) {
+		// Swift overwrites theses mappings and the local dev config file in the _transformCredentialsOutput() function below,
+		// while we are awaiting fine-grained vs. coarse-grained approaches for laying down credential.
+		console.log("Language swift kitura mappings")
 		let mappingsFilePath = this.destinationPath(PATH_MAPPINGS_FILE);
 		this.fs.extendJSON(mappingsFilePath, serviceMappingsJSON);
 	}
@@ -150,7 +153,7 @@ module.exports = class extends Generator {
 		let serviceCredentials = {};
 		credentials[instanceName] = serviceCredentials;
 		// Note that environment variables should not use the '-' character
-		const envVariableName = instanceName.replace(/-/g, "_");
+		const envVariableName = 'service_' + prefix
 		mappings[prefix] = {
 			"searchPatterns": [
 				"cloudfoundry:" + instanceName,

--- a/test/app-swift-kitura-test.js
+++ b/test/app-swift-kitura-test.js
@@ -303,7 +303,7 @@ function testServiceInstrumentation(serviceName, servLookupKey, codeForServices)
 }
 
 function testMappings(servLookupKey, servInstanceName) {
-	const envVariableName = servInstanceName.replace(/-/g, "_");
+	const envVariableName = 'service_' + servLookupKey;
 	const expectedMappings = {
 		[servLookupKey]: {
 			searchPatterns: [


### PR DESCRIPTION
Fix for issue [64](https://github.ibm.com/arf/planning-languages/issues/64).

### Issue
At some point, the generator was updated to bind services to kubernetes with the naming format `service_<service>`, this works for all the languages but swift, since it has an unusual setup due to current limitations in CloudEnvironment. Rather than using the default file format, swift injects names using the actual service instance name. 

### Fix
This addresses the problem by changing the kubernetes name to the proper format.
