### PR TITLE
fix: adding back support for Node 4

### DIFF
--- a/generators/lib/generatorbase.js
+++ b/generators/lib/generatorbase.js
@@ -25,11 +25,11 @@ const Handlebars = require('handlebars');
 const REGEX_HYPHEN = /-/g;
 
 module.exports = class extends Generator {
-	constructor(args, opts, scaffolderName, cloudFoundryName, customServiceKey = null, customCredKeys = []) {
+	constructor(args, opts, scaffolderName, cloudFoundryName, customServiceKey, customCredKeys) {
 		super(args, opts);
 		this.scaffolderName = scaffolderName;
 		this.serviceKey = customServiceKey || scaffolderName;
-		this.customCredKeys= customCredKeys
+		this.customCredKeys= customCredKeys || [];
 		this.logger = log4js.getLogger("generator-ibm-service-enablement:" + scaffolderName);
 		this.context = opts.context;
 		this.cloudFoundryName = this.context.cloudLabel || cloudFoundryName;


### PR DESCRIPTION
Node 4 does not support default parameters.  This solution resolves problems for **generator-swiftserver** which still supports Node 4.