### PR TITLE
feat: Update Swift-Kuery-ORM for Kitura 2.4

### DIFF
--- a/generators/service-elephant-sql/templates/swift/dependencies.txt
+++ b/generators/service-elephant-sql/templates/swift/dependencies.txt
@@ -1,2 +1,2 @@
 .package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL", from: "1.1.0"),
-.package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM", from: "0.0.1"),
+.package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM", from: "0.1.0"),

--- a/generators/service-postgre/templates/swift/dependencies.txt
+++ b/generators/service-postgre/templates/swift/dependencies.txt
@@ -1,2 +1,2 @@
 .package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL", from: "1.1.0"),
-.package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM", from: "0.0.1"),
+.package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM", from: "0.1.0"),


### PR DESCRIPTION
In order to update Kitura to `2.4` in the **generator-swiftserver**, the version of the Swift-Kuery-ORM needs to be update due to the dependency clash of KituraContracts