### PR TITLE
fix: swiftserver mapping production for non-supported services

### DIFF
--- a/generators/lib/generatorbase.js
+++ b/generators/lib/generatorbase.js
@@ -41,19 +41,19 @@ module.exports = class extends Generator {
 	initializing() {
 		//do nothing by default
 	}
-	
+
 	/**
 	 * The configuration context for service generators. This phase will excuted the appropriate methods to add the mappings, implementation code, and deployment configurtation for each service.
-	 * There are few caveats to take note 
+	 * There are few caveats to take note
 	 *
 	 *	Only add service credentials to the pipeline.yml if service information (e.g. label, name, etc) exist for that that servive
-	 *	Only add mapping file and local-dev config file if the service is not autoscaling or the service does not an SDK available 
-	 *  
+	 *	Only add mapping file and local-dev config file if the service is not autoscaling or the service does not have an SDK
+	 *
 	 *
 	 * @param config
 	 * @returns {undefined}
 	 */
-	
+
 	configuring(config) {
 		this.hasBluemixProperty = this.context.bluemix.hasOwnProperty(this.scaffolderName);
 		this.hasTemplate = fs.existsSync(this.languageTemplatePath);
@@ -179,6 +179,7 @@ module.exports = class extends Generator {
 	}
 
 	_addMappings(config) {
+		if (this.context.language === "swift") return;
 		this.logger.info("Adding mappings");
 
 		let serviceCredentials = Array.isArray(this.context.bluemix[this.scaffolderName])


### PR DESCRIPTION
The changes applied in #278 were made to pass through mappings and local credentials for services that were not officially supported.  This was a request made by the codgen team, who support many services beyond the ones for which we provide instrumentation code. The rationale for this was that developers could write their own logic & instrumentation code.

This implementation did not work for Swift, resulting in crashes due to malformed templates.  Due to the lack of a JSON path library in Swift, we have always written our own *mappings.json* with a coarse grained access model in `language-swift-kitura`.  This implementation has been closely tied to CloudEnvironment, our credentials parsing library.  

Historically, the mappings.json file has been generated for all languages, and then Swift would overwrite the file.  This new line stops the generation of the initial mappings.json, which works for the other languages.