### PR TITLE
fix: use scoped cloudant package

### DIFF
--- a/generators/service-cloudant/templates/node/dependencies.json
+++ b/generators/service-cloudant/templates/node/dependencies.json
@@ -1,5 +1,5 @@
 {
 	"dependencies": {
-		"cloudant": "^1.10.0"
+		"@cloudant/cloudant": "^1.10.0"
 	}
 }

--- a/generators/service-cloudant/templates/node/instrumentation.js
+++ b/generators/service-cloudant/templates/node/instrumentation.js
@@ -1,9 +1,7 @@
 const IBMCloudEnv = require('ibm-cloud-env');
-const CloudantSDK = require('cloudant');
+const CloudantSDK = require('@cloudant/cloudant');
 
 module.exports = function(app, serviceManager){
 	const cloudant = new CloudantSDK(IBMCloudEnv.getString('cloudant_url'));
 	serviceManager.set('cloudant', cloudant);
 };
-
-


### PR DESCRIPTION
This change addresses this message in the output of generated node applications that use Cloudant:

> npm WARN deprecated cloudant@1.10.0: This package is now scoped. The new name is @cloudant/cloudant