### PR TITLE
fix: fixing cloudObjectStorage devexId

### DIFF
--- a/generators/resources/scaffolderMapping.json
+++ b/generators/resources/scaffolderMapping.json
@@ -3,7 +3,7 @@
   "apache-spark": "apacheSpark",
   "appid": "appid",
   "autoscaling": "autoScaling",
-  "cloud-object-storage": "cloudobjectstorage",
+  "cloud-object-storage": "cloudObjectStorage",
   "postgre": "postgresql",
   "cloudant": "cloudant",
   "hypersecure-dbaas-mongodb": "hypersecuredb",

--- a/generators/service-cloud-object-storage/index.js
+++ b/generators/service-cloud-object-storage/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BaseGenerator = require('../lib/generatorbase');
-const SCAFFOLDER_PROJECT_PROPERTY_NAME = 'cloudobjectstorage';
+const SCAFFOLDER_PROJECT_PROPERTY_NAME = 'cloudObjectStorage';
 const CLOUD_FOUNDRY_SERVICE_NAME = 'cloud-object-storage';
 const CUSTOM_SERVICE_KEY = 'cloud-object-storage';
 

--- a/test/app-node-express-test.js
+++ b/test/app-node-express-test.js
@@ -67,13 +67,13 @@ describe('node-express', function () {
 
 	it('Can add Cloud Object Storage instrumentation', () => {
 		testAll('cloud-object-storage', {
-			cloud_object_storage_apikey: optionsBluemix.cloudobjectstorage.apikey,
-			cloud_object_storage_endpoints: optionsBluemix.cloudobjectstorage.endpoints,
-			cloud_object_storage_iam_apikey_description: optionsBluemix.cloudobjectstorage.iam_apikey_description,
-			cloud_object_storage_iam_apikey_name: optionsBluemix.cloudobjectstorage.iam_apikey_name,
-			cloud_object_storage_iam_role_crn: optionsBluemix.cloudobjectstorage.iam_role_crn,
-			cloud_object_storage_iam_serviceid_crn: optionsBluemix.cloudobjectstorage.iam_serviceid_crn,
-			cloud_object_storage_resource_instance_id: optionsBluemix.cloudobjectstorage.resource_instance_id
+			cloud_object_storage_apikey: optionsBluemix.cloudObjectStorage.apikey,
+			cloud_object_storage_endpoints: optionsBluemix.cloudObjectStorage.endpoints,
+			cloud_object_storage_iam_apikey_description: optionsBluemix.cloudObjectStorage.iam_apikey_description,
+			cloud_object_storage_iam_apikey_name: optionsBluemix.cloudObjectStorage.iam_apikey_name,
+			cloud_object_storage_iam_role_crn: optionsBluemix.cloudObjectStorage.iam_role_crn,
+			cloud_object_storage_iam_serviceid_crn: optionsBluemix.cloudObjectStorage.iam_serviceid_crn,
+			cloud_object_storage_resource_instance_id: optionsBluemix.cloudObjectStorage.resource_instance_id
 		})
 	})
 

--- a/test/lib/service-helpers.js
+++ b/test/lib/service-helpers.js
@@ -43,15 +43,15 @@ function serviceCloudant(optionsBluemix) {
 function serviceCloudObjectStorage(optionsBluemix) {
 	return {
 		location: `service-cloud-object-storage`,
-		bluemixName: `cloudobjectstorage`,
+		bluemixName: `cloudObjectStorage`,
 		localDevConfig: {
-			cloud_object_storage_apikey: optionsBluemix.cloudobjectstorage.apikey,
-			cloud_object_storage_endpoints: optionsBluemix.cloudobjectstorage.endpoints,
-			cloud_object_storage_iam_apikey_description: optionsBluemix.cloudobjectstorage.iam_apikey_description,
-			cloud_object_storage_iam_apikey_name: optionsBluemix.cloudobjectstorage.iam_apikey_name,
-			cloud_object_storage_iam_role_crn: optionsBluemix.cloudobjectstorage.iam_role_crn,
-			cloud_object_storage_iam_serviceid_crn: optionsBluemix.cloudobjectstorage.iam_serviceid_crn,
-			cloud_object_storage_resource_instance_id: optionsBluemix.cloudobjectstorage.resource_instance_id
+			cloud_object_storage_apikey: optionsBluemix.cloudObjectStorage.apikey,
+			cloud_object_storage_endpoints: optionsBluemix.cloudObjectStorage.endpoints,
+			cloud_object_storage_iam_apikey_description: optionsBluemix.cloudObjectStorage.iam_apikey_description,
+			cloud_object_storage_iam_apikey_name: optionsBluemix.cloudObjectStorage.iam_apikey_name,
+			cloud_object_storage_iam_role_crn: optionsBluemix.cloudObjectStorage.iam_role_crn,
+			cloud_object_storage_iam_serviceid_crn: optionsBluemix.cloudObjectStorage.iam_serviceid_crn,
+			cloud_object_storage_resource_instance_id: optionsBluemix.cloudObjectStorage.resource_instance_id
 		},
 		instrumentation: {
 			java_liberty: [{

--- a/test/resources/bluemix.json
+++ b/test/resources/bluemix.json
@@ -138,7 +138,7 @@
       }
     }
   ],
-  "cloudobjectstorage": {
+  "cloudObjectStorage": {
     "apikey": "apikey",
     "endpoints": "endpoints",
     "iam_apikey_description": "iam_apikey_description",


### PR DESCRIPTION
This change addresses an error where apps with [Cloud Object Storage](https://www.bluemix.net/docs/services/cloud-object-storage/about-cos.html) were not being created with credentials or instrumentation code.