### PR TITLE
fix: upgrade the Watson SDK in Swift

### DIFF
--- a/generators/service-watson-assistant/templates/swift/dependencies.txt
+++ b/generators/service-watson-assistant/templates/swift/dependencies.txt
@@ -1,1 +1,1 @@
-.package(url: "https://github.com/watson-developer-cloud/swift-sdk.git", .upToNextMinor(from: "0.28.0")),
+.package(url: "https://github.com/watson-developer-cloud/swift-sdk.git", .upToNextMinor(from: "0.37.0")),


### PR DESCRIPTION
This addresses a problem with a dependency of the Watson SDK, which dropped support for Xcode 9 in a patch release.  See  https://github.com/daltoniam/Starscream/issues/587.