### PR TITLE
chore: upgrade Watson SDK dependency for Swift

### DIFF
--- a/generators/service-watson-assistant/templates/swift/dependencies.txt
+++ b/generators/service-watson-assistant/templates/swift/dependencies.txt
@@ -1,1 +1,1 @@
-.package(url: "https://github.com/watson-developer-cloud/swift-sdk.git", .upToNextMinor(from: "0.37.0")),
+.package(url: "https://github.com/watson-developer-cloud/swift-sdk.git", from: "1.2.0"),


### PR DESCRIPTION
This dependency is upgraded to the latest major version of the Watson SDK, and relaxes the versioning requirement now that the 1.0.0 release has stabilized.