### PR TITLE
fix: update the version and url for the Go SDK

### DIFF
--- a/generators/service-watson-conversation/templates/go/dependencies.toml
+++ b/generators/service-watson-conversation/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
   name = "github.com/watson-developer-cloud/go-sdk"
-  version = "0.7.0"
+  version = "0.8.0"

--- a/generators/service-watson-discovery/templates/go/dependencies.toml
+++ b/generators/service-watson-discovery/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-discovery/templates/go/instrumentation.go
+++ b/generators/service-watson-discovery/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/discoveryv1"
+	"github.com/watson-developer-cloud/go-sdk/discoveryv1"
 )
 
 // InitializeServiceWatsonDiscovery uses IBMCloudEnv to find credentials

--- a/generators/service-watson-discovery/templates/go/meta.json
+++ b/generators/service-watson-discovery/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/discoveryv1",
+  "import":"github.com/watson-developer-cloud/go-sdk/discoveryv1",
   "variableName":"WatsonDiscovery",
   "type":"discoveryv1.DiscoveryV1"
 }

--- a/generators/service-watson-language-translator/templates/go/dependencies.toml
+++ b/generators/service-watson-language-translator/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-language-translator/templates/go/instrumentation.go
+++ b/generators/service-watson-language-translator/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/languagetranslatorv3"
+	"github.com/watson-developer-cloud/go-sdk/languagetranslatorv3"
 )
 
 // InitializeServiceWatsonLanguageTranslator uses IBMCloudEnv to find credentials

--- a/generators/service-watson-language-translator/templates/go/meta.json
+++ b/generators/service-watson-language-translator/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/languagetranslatorv3",
+  "import":"github.com/watson-developer-cloud/go-sdk/languagetranslatorv3",
   "variableName":"WatsonLanguageTranslator",
   "type":"languagetranslatorv3.LanguageTranslatorV3"
 }

--- a/generators/service-watson-natural-language-classifier/templates/go/dependencies.toml
+++ b/generators/service-watson-natural-language-classifier/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-natural-language-classifier/templates/go/instrumentation.go
+++ b/generators/service-watson-natural-language-classifier/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/naturallanguageclassifierv1"
+	"github.com/watson-developer-cloud/go-sdk/naturallanguageclassifierv1"
 )
 
 // InitializeServiceWatsonNaturalLanguageClassifier uses IBMCloudEnv to find credentials

--- a/generators/service-watson-natural-language-classifier/templates/go/meta.json
+++ b/generators/service-watson-natural-language-classifier/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/naturallanguageclassifierv1",
+  "import":"github.com/watson-developer-cloud/go-sdk/naturallanguageclassifierv1",
   "variableName":"WatsonNaturalLanguageClassifier",
   "type":"naturallanguageclassifierv1.NaturalLanguageClassifierV1"
 }

--- a/generators/service-watson-natural-language-understanding/templates/go/dependencies.toml
+++ b/generators/service-watson-natural-language-understanding/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-natural-language-understanding/templates/go/instrumentation.go
+++ b/generators/service-watson-natural-language-understanding/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/naturallanguageunderstandingv1"
+	"github.com/watson-developer-cloud/go-sdk/naturallanguageunderstandingv1"
 )
 
 // InitializeServiceWatsonNaturalLanguageUnderstanding uses IBMCloudEnv to find credentials

--- a/generators/service-watson-natural-language-understanding/templates/go/meta.json
+++ b/generators/service-watson-natural-language-understanding/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/naturallanguageunderstandingv1",
+  "import":"github.com/watson-developer-cloud/go-sdk/naturallanguageunderstandingv1",
   "variableName":"WatsonNaturalLanguageUnderstanding",
   "type":"naturallanguageunderstandingv1.NaturalLanguageUnderstandingV1"
 }

--- a/generators/service-watson-personality-insights/templates/go/dependencies.toml
+++ b/generators/service-watson-personality-insights/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-personality-insights/templates/go/instrumentation.go
+++ b/generators/service-watson-personality-insights/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/personalityinsightsv3"
+	"github.com/watson-developer-cloud/go-sdk/personalityinsightsv3"
 )
 
 // InitializeServiceWatsonPersonalityInsights uses IBMCloudEnv to find credentials

--- a/generators/service-watson-personality-insights/templates/go/meta.json
+++ b/generators/service-watson-personality-insights/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/personalityinsightsv3",
+  "import":"github.com/watson-developer-cloud/go-sdk/personalityinsightsv3",
   "variableName":"WatsonPersonalityInsights",
   "type":"personalityinsightsv3.PersonalityInsightsV3"
 }

--- a/generators/service-watson-speech-to-text/templates/go/dependencies.toml
+++ b/generators/service-watson-speech-to-text/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-speech-to-text/templates/go/instrumentation.go
+++ b/generators/service-watson-speech-to-text/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/speechtotextv1"
+	"github.com/watson-developer-cloud/go-sdk/speechtotextv1"
 )
 
 // InitializeServiceWatsonSpeechToText uses IBMCloudEnv to find credentials

--- a/generators/service-watson-speech-to-text/templates/go/meta.json
+++ b/generators/service-watson-speech-to-text/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/speechtotextv1",
+  "import":"github.com/watson-developer-cloud/go-sdk/speechtotextv1",
   "variableName":"WatsonSpeechToText",
   "type":"speechtotextv1.SpeechToTextV1"
 }

--- a/generators/service-watson-text-to-speech/templates/go/dependencies.toml
+++ b/generators/service-watson-text-to-speech/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-text-to-speech/templates/go/instrumentation.go
+++ b/generators/service-watson-text-to-speech/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/texttospeechv1"
+	"github.com/watson-developer-cloud/go-sdk/texttospeechv1"
 )
 
 // InitializeServiceWatsonTextToSpeech uses IBMCloudEnv to find credentials

--- a/generators/service-watson-text-to-speech/templates/go/meta.json
+++ b/generators/service-watson-text-to-speech/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/texttospeechv1",
+  "import":"github.com/watson-developer-cloud/go-sdk/texttospeechv1",
   "variableName":"WatsonTextToSpeech",
   "type":"texttospeechv1.TextToSpeechV1"
 }

--- a/generators/service-watson-tone-analyzer/templates/go/dependencies.toml
+++ b/generators/service-watson-tone-analyzer/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/watson-developer-cloud/golang-sdk"
-  version = "0.7.0"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  version = "0.8.0"

--- a/generators/service-watson-tone-analyzer/templates/go/instrumentation.go
+++ b/generators/service-watson-tone-analyzer/templates/go/instrumentation.go
@@ -3,7 +3,7 @@ package services
 import (
 	"errors"
 	"github.com/ibm-developer/ibm-cloud-env-golang"
-	"github.com/watson-developer-cloud/golang-sdk/toneanalyzerv3"
+	"github.com/watson-developer-cloud/go-sdk/toneanalyzerv3"
 )
 
 // InitializeServiceWatsonToneAnalyzer uses IBMCloudEnv to find credentials

--- a/generators/service-watson-tone-analyzer/templates/go/meta.json
+++ b/generators/service-watson-tone-analyzer/templates/go/meta.json
@@ -1,5 +1,5 @@
 {
-  "import":"github.com/watson-developer-cloud/golang-sdk/toneanalyzerv3",
+  "import":"github.com/watson-developer-cloud/go-sdk/toneanalyzerv3",
   "variableName":"WatsonToneAnalyzer",
   "type":"toneanalyzerv3.ToneAnalyzerV3"
 }

--- a/generators/service-watson-visual-recognition/templates/go/dependencies.toml
+++ b/generators/service-watson-visual-recognition/templates/go/dependencies.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
   name = "github.com/watson-developer-cloud/go-sdk"
-  version = "0.7.0"
+  version = "0.8.0"


### PR DESCRIPTION
Updates the [Go SDK](https://github.com/watson-developer-cloud/go-sdk) to version `0.8.0`.