### PR TITLE
fix: replace mustache tags with service instance name

### DIFF
--- a/generators/language-go/index.js
+++ b/generators/language-go/index.js
@@ -173,12 +173,10 @@ module.exports = class extends Generator {
 		// add services secretKeyRefs to deployment.yaml && 
 		// add services properties and cf bind-service to pipeline.yml &&
 		// add services secretKeyRefs to values.yaml &&
-		// add services form parameters to toolchain.yml && 
 		// add secretKeyRefs to helm commands in kube_deploy.sh
 		return Utils.addServicesEnvToHelmChartAsync({context: this.context, destinationPath: this.destinationPath()})
 			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}))
 			.then(() => Utils.addServicesEnvToValuesAsync({context: this.context, destinationPath: this.destinationPath()}))
-			.then(() => Utils.addServicesEnvToToolchainAsync({context: this.context, destinationPath: this.destinationPath()}))
 			.then(() => Utils.addServicesKeysToKubeDeployAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 

--- a/generators/language-java/index.js
+++ b/generators/language-java/index.js
@@ -180,12 +180,10 @@ module.exports = class extends Generator {
 		// add services secretKeyRefs to deployment.yaml && 
 		// add services properties and cf bind-service to pipeline.yml &&
 		// add services secretKeyRefs to values.yaml &&
-		// add services form parameters to toolchain.yml && 
 		// add secretKeyRefs to helm commands in kube_deploy.sh
 		return Utils.addServicesEnvToHelmChartAsync({ context: this.context, destinationPath: this.destinationPath() })
 			.then(() => Utils.addServicesToPipelineYamlAsync({ context: this.context, destinationPath: this.destinationPath() }))
 			.then(() => Utils.addServicesEnvToValuesAsync({context: this.context, destinationPath: this.destinationPath()}))
-			.then(() => Utils.addServicesEnvToToolchainAsync({ context: this.context, destinationPath: this.destinationPath() }))
 			.then(() => Utils.addServicesKeysToKubeDeployAsync({ context: this.context, destinationPath: this.destinationPath() }));
 	}
 };

--- a/generators/language-node-express/index.js
+++ b/generators/language-node-express/index.js
@@ -129,12 +129,10 @@ module.exports = class extends Generator {
 		// add services secretKeyRefs to deployment.yaml && 
 		// add services properties and cf bind-service to pipeline.yml &&
 		// add services secretKeyRefs to values.yaml &&
-		// add services form parameters to toolchain.yml && 
 		// add secretKeyRefs to helm commands in kube_deploy.sh
 		return Utils.addServicesEnvToHelmChartAsync({context: this.context, destinationPath: this.destinationPath()})
 			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}))
 			.then(() => Utils.addServicesEnvToValuesAsync({context: this.context, destinationPath: this.destinationPath()}))
-			.then(() => Utils.addServicesEnvToToolchainAsync({context: this.context, destinationPath: this.destinationPath()}))
 			.then(() => Utils.addServicesKeysToKubeDeployAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 };

--- a/generators/language-python-flask/index.js
+++ b/generators/language-python-flask/index.js
@@ -297,12 +297,10 @@ module.exports = class extends Generator {
 		// add services secretKeyRefs to deployment.yaml && 
 		// add services properties and cf bind-service to pipeline.yml &&
 		// add services secretKeyRefs to values.yaml &&
-		// add services form parameters to toolchain.yml && 
 		// add secretKeyRefs to helm commands in kube_deploy.sh
 		return Utils.addServicesEnvToHelmChartAsync({context: this.context, destinationPath: this.destinationPath()})
 			.then(() => Utils.addServicesToPipelineYamlAsync({context: this.context, destinationPath: this.destinationPath()}))
 			.then(() => Utils.addServicesEnvToValuesAsync({context: this.context, destinationPath: this.destinationPath()}))
-			.then(() => Utils.addServicesEnvToToolchainAsync({context: this.context, destinationPath: this.destinationPath()}))
 			.then(() => Utils.addServicesKeysToKubeDeployAsync({context: this.context, destinationPath: this.destinationPath()}));
 	}
 };

--- a/generators/language-swift-kitura/index.js
+++ b/generators/language-swift-kitura/index.js
@@ -273,12 +273,10 @@ module.exports = class extends Generator {
 		// add services secretKeyRefs to deployment.yaml &&
 		// add services properties and cf bind-service to pipeline.yml &&
 		// add services secretKeyRefs to values.yaml &&
-		// add services form parameters to toolchain.yml &&
 		// add secretKeyRefs to helm commands in kube_deploy.sh
 		return Utils.addServicesEnvToHelmChartAsync({ context: this.context, destinationPath: this.destinationPath() })
 			.then(() => Utils.addServicesToPipelineYamlAsync({ context: this.context, destinationPath: this.destinationPath() }))
 			.then(() => Utils.addServicesEnvToValuesAsync({ context: this.context, destinationPath: this.destinationPath() }))
-			.then(() => Utils.addServicesEnvToToolchainAsync({ context: this.context, destinationPath: this.destinationPath() }))
 			.then(() => Utils.addServicesKeysToKubeDeployAsync({ context: this.context, destinationPath: this.destinationPath() }));
 	}
 };

--- a/generators/lib/Utils.js
+++ b/generators/lib/Utils.js
@@ -10,13 +10,7 @@ const SPRING_BOOT_SERVICE_KEY_SEPARATOR = "spring_boot_service_key_separator";
 // consts used for pipeline.yml
 const REGEX_PORT = /^(\s*)- name: PORT/;
 const REGEX_DEPLOY = /- name: Deploy Stage/;
-const REGEX_BUILD = /- name: Build Stage/;
 const REGEX_CF_LOGS = /cf\slogs/;
-const REGEX_CHART_NAME = /- name: CHART_NAME/;
-
-// consts used for toolchain.yml
-// const REGEX_KUBE_CLUSTER_NAME_UPPER = /KUBE_CLUSTER_NAME/;
-// const REGEX_KUBE_CLUSTER_NAME_LOWER = /kube-cluster-name/;
 
 // consts used for kube_deploy.sh
 const REGEX_HELM_UPGRADE = /helm(\s*)upgrade(\s*)--install(\s*)\$\{RELEASE_NAME\}(\s*).\/chart\/\$\{CHART_NAME\}/;
@@ -229,27 +223,14 @@ function addServicesToPipelineYamlAsync(args) {
 		});
 		let rl = readline.createInterface({ input: readStream });
 
-		let pipelineFileString = '', deployBool = false,
-			buildBool = false, chartNameBool = false;
-
+		let pipelineFileString = '', deployBool = false
+		
 		rl.on('line', (line) => {
 
-			if (line.search(REGEX_BUILD) > -1) { buildBool = true; }
 			if (line.search(REGEX_DEPLOY) > -1) { deployBool = true; }
-			if (line.search(REGEX_CHART_NAME) > -1) { chartNameBool = true; }
-
 			let cfLogsIndex = line.search(REGEX_CF_LOGS);
 			
-			// insert new properties above CHART_NAME property in Build and Deploy stages-- 
-			// only for Kube deploys, which should always have the CHART_NAME property
-			if (buildBool && chartNameBool ||
-				deployBool && chartNameBool) {
-				// pipelineFileString += generateServiceProperties(context.deploymentServicesEnv);
-				// pipelineFileString += `${line}\n`;
-				// // all done with Build Stage + properties section, don't reset deployBool
-				// buildBool = false, chartNameBool = false;
-			}
-			else if (cfLogsIndex > -1 && deployBool) {
+			if (cfLogsIndex > -1 && deployBool) {
 
 				logger.info(`pipeline.yaml cf section-- adding create-service command(s)`);
 				let spacesPrefix = "      ";
@@ -304,73 +285,6 @@ function getSpringServiceInfo(regularServiceKey) {
 	return value;
 }
 
-// add form params for each service in toolchain.yml
-// function addServicesEnvToToolchainAsync(args) {
-// 	return new Promise((resolve, reject) => {
-// 		let context = args.context;
-// 		let destinationPath = args.destinationPath;
-
-// 		// this toolchain.yml file should've been generated in the generator-ibm-cloud-enablement generator
-// 		let toolchainFilePath = `${destinationPath}/.bluemix/toolchain.yml`;
-// 		logger.info(`toolchain.yml path: ${toolchainFilePath}`);
-
-// 		let toolchainFileExists = fs.existsSync(toolchainFilePath);
-// 		if (!toolchainFileExists) { return resolve(); }
-
-// 		let hasServices = context.servicesInfo && context.servicesInfo.length > 0;
-// 		if (!hasServices) { return resolve(); }
-// 		logger.info("toolchain.yml exists, setting parameters for services");
-// 		logger.info(`has ${context.deploymentServicesEnv.length} services, adding to toolchain.yml`);
-
-// 		let readStream = fs.createReadStream(toolchainFilePath);
-// 		let promiseIsRejected = false;
-// 		readStream.on('error', (err) => {
-// 			logger.error('failed to read toolchain.yml from filesystem: ' + err.message);
-// 			reject(err);
-// 			promiseIsRejected = true;
-// 		});
-// 		let rl = readline.createInterface({ input: readStream });
-
-// 		let toolchainFileString = '';
-// 		let whitespace10 = "          ", whitespace6 = "      ";
-// 		rl.on('line', (line) => {
-
-// 			if (line.search(REGEX_KUBE_CLUSTER_NAME_UPPER) > -1) {
-// 				//add service vars above or below
-// 				context.deploymentServicesEnv.forEach(function (service) {
-// 					//should look like this: CONVERSATION: "{{form.pipeline.parameters.conversation}}"
-// 					toolchainFileString += (whitespace10 +
-// 						service.scaffolderName.toUpperCase() + ": \"{{form.pipeline.parameters." + service.scaffolderName + "}}\"\n");
-// 				})
-// 			}
-// 			else if (line.search(REGEX_KUBE_CLUSTER_NAME_LOWER) > -1) {
-// 				//add form params above or below
-
-// 				context.deploymentServicesEnv.forEach(function (service) {
-// 					//should look like this: conversation: "{{conversation}}"
-// 					toolchainFileString += (whitespace6 +
-// 						service.scaffolderName + ": \"{{" + service.scaffolderName + "}}\"\n");
-// 				})
-
-// 			}
-// 			toolchainFileString += `${line}\n`;
-
-
-// 		}).on('close', () => {
-// 			if (promiseIsRejected) { return; }
-// 			fs.writeFile(toolchainFilePath, toolchainFileString, (err) => {
-// 				if (err) {
-// 					logger.error('failed to write updated toolchain.yml to filesystem: ' + err.message);
-// 					reject(err);
-// 				} else {
-// 					logger.info('finished updating toolchain.yml and wrote to filesystem');
-// 					resolve();
-// 				}
-// 			});
-// 		});
-// 	})
-// }
-
 // add secretKeyRefs to kube_deploy.sh helm commands
 function addServicesKeysToKubeDeployAsync(args) {
 	return new Promise((resolve, reject) => {
@@ -405,8 +319,7 @@ function addServicesKeysToKubeDeployAsync(args) {
 			if (line.search(REGEX_HELM_UPGRADE) > -1) {
 				let str = '';
 				context.deploymentServicesEnv.forEach(function (service) {
-					// str += ",services." + service.scaffolderName + ".secretKeyRef=${" + service.scaffolderName.toUpperCase() + "}";
-					str += ",services." + service.scaffolderName + ".secretKeyRef=" + service.valueFrom.secretKeyRef ;
+					str += ",services." + service.scaffolderName + ".secretKeyRef=" + service.valueFrom.secretKeyRef;
 				})
 				kubeDeployFileString += `${line}` + str + "\n";
 			}
@@ -448,22 +361,10 @@ function generateSecretRefsValues(services) {
 	services.forEach((serviceEntry) => {
 		servicesEnvString +=
 			`  ${serviceEntry.scaffolderName}:\n` +
-			// `    secretKeyRef: \${${serviceEntry.scaffolderName.toUpperCase()}}\n`;
-			`    secretKeyRef: ${serviceEntry.valueFrom.secretKeyRef.key}\n`;
+			`    secretKeyRef: ${serviceEntry.keyName}\n`;
 	});
 	return servicesEnvString;
 }
-
-// function generateServiceProperties(services) {
-// 	let servicesEnvString = '';
-// 	services.forEach((serviceEntry) => {
-// 		servicesEnvString +=
-// 			`  - name: ` + serviceEntry.scaffolderName.toUpperCase() + `\n` +
-// 			`    value: \${` + serviceEntry.scaffolderName.toUpperCase() + `}\n` +
-// 			`    type: text\n`
-// 	});
-// 	return servicesEnvString;
-// }
 
 module.exports = {
 	getSpringServiceInfo: getSpringServiceInfo,
@@ -472,6 +373,5 @@ module.exports = {
 	addServicesEnvToHelmChartAsync: addServicesEnvToHelmChartAsync,
 	addServicesToPipelineYamlAsync: addServicesToPipelineYamlAsync,
 	addServicesEnvToValuesAsync: addServicesEnvToValuesAsync,
-	// addServicesEnvToToolchainAsync: addServicesEnvToToolchainAsync,
 	addServicesKeysToKubeDeployAsync: addServicesKeysToKubeDeployAsync
 };

--- a/generators/lib/Utils.js
+++ b/generators/lib/Utils.js
@@ -319,7 +319,7 @@ function addServicesKeysToKubeDeployAsync(args) {
 			if (line.search(REGEX_HELM_UPGRADE) > -1) {
 				let str = '';
 				context.deploymentServicesEnv.forEach(function (service) {
-					str += ",services." + service.scaffolderName + ".secretKeyRef=" + service.valueFrom.secretKeyRef;
+					str += ",services." + service.scaffolderName + ".secretKeyRef=" + service.keyName;
 				})
 				kubeDeployFileString += `${line}` + str + "\n";
 			}

--- a/generators/lib/Utils.js
+++ b/generators/lib/Utils.js
@@ -15,8 +15,8 @@ const REGEX_CF_LOGS = /cf\slogs/;
 const REGEX_CHART_NAME = /- name: CHART_NAME/;
 
 // consts used for toolchain.yml
-const REGEX_KUBE_CLUSTER_NAME_UPPER = /KUBE_CLUSTER_NAME/;
-const REGEX_KUBE_CLUSTER_NAME_LOWER = /kube-cluster-name/;
+// const REGEX_KUBE_CLUSTER_NAME_UPPER = /KUBE_CLUSTER_NAME/;
+// const REGEX_KUBE_CLUSTER_NAME_LOWER = /kube-cluster-name/;
 
 // consts used for kube_deploy.sh
 const REGEX_HELM_UPGRADE = /helm(\s*)upgrade(\s*)--install(\s*)\$\{RELEASE_NAME\}(\s*).\/chart\/\$\{CHART_NAME\}/;
@@ -244,10 +244,10 @@ function addServicesToPipelineYamlAsync(args) {
 			// only for Kube deploys, which should always have the CHART_NAME property
 			if (buildBool && chartNameBool ||
 				deployBool && chartNameBool) {
-				pipelineFileString += generateServiceProperties(context.deploymentServicesEnv);
-				pipelineFileString += `${line}\n`;
-				// all done with Build Stage + properties section, don't reset deployBool
-				buildBool = false, chartNameBool = false;
+				// pipelineFileString += generateServiceProperties(context.deploymentServicesEnv);
+				// pipelineFileString += `${line}\n`;
+				// // all done with Build Stage + properties section, don't reset deployBool
+				// buildBool = false, chartNameBool = false;
 			}
 			else if (cfLogsIndex > -1 && deployBool) {
 
@@ -305,71 +305,71 @@ function getSpringServiceInfo(regularServiceKey) {
 }
 
 // add form params for each service in toolchain.yml
-function addServicesEnvToToolchainAsync(args) {
-	return new Promise((resolve, reject) => {
-		let context = args.context;
-		let destinationPath = args.destinationPath;
+// function addServicesEnvToToolchainAsync(args) {
+// 	return new Promise((resolve, reject) => {
+// 		let context = args.context;
+// 		let destinationPath = args.destinationPath;
 
-		// this toolchain.yml file should've been generated in the generator-ibm-cloud-enablement generator
-		let toolchainFilePath = `${destinationPath}/.bluemix/toolchain.yml`;
-		logger.info(`toolchain.yml path: ${toolchainFilePath}`);
+// 		// this toolchain.yml file should've been generated in the generator-ibm-cloud-enablement generator
+// 		let toolchainFilePath = `${destinationPath}/.bluemix/toolchain.yml`;
+// 		logger.info(`toolchain.yml path: ${toolchainFilePath}`);
 
-		let toolchainFileExists = fs.existsSync(toolchainFilePath);
-		if (!toolchainFileExists) { return resolve(); }
+// 		let toolchainFileExists = fs.existsSync(toolchainFilePath);
+// 		if (!toolchainFileExists) { return resolve(); }
 
-		let hasServices = context.servicesInfo && context.servicesInfo.length > 0;
-		if (!hasServices) { return resolve(); }
-		logger.info("toolchain.yml exists, setting parameters for services");
-		logger.info(`has ${context.deploymentServicesEnv.length} services, adding to toolchain.yml`);
+// 		let hasServices = context.servicesInfo && context.servicesInfo.length > 0;
+// 		if (!hasServices) { return resolve(); }
+// 		logger.info("toolchain.yml exists, setting parameters for services");
+// 		logger.info(`has ${context.deploymentServicesEnv.length} services, adding to toolchain.yml`);
 
-		let readStream = fs.createReadStream(toolchainFilePath);
-		let promiseIsRejected = false;
-		readStream.on('error', (err) => {
-			logger.error('failed to read toolchain.yml from filesystem: ' + err.message);
-			reject(err);
-			promiseIsRejected = true;
-		});
-		let rl = readline.createInterface({ input: readStream });
+// 		let readStream = fs.createReadStream(toolchainFilePath);
+// 		let promiseIsRejected = false;
+// 		readStream.on('error', (err) => {
+// 			logger.error('failed to read toolchain.yml from filesystem: ' + err.message);
+// 			reject(err);
+// 			promiseIsRejected = true;
+// 		});
+// 		let rl = readline.createInterface({ input: readStream });
 
-		let toolchainFileString = '';
-		let whitespace10 = "          ", whitespace6 = "      ";
-		rl.on('line', (line) => {
+// 		let toolchainFileString = '';
+// 		let whitespace10 = "          ", whitespace6 = "      ";
+// 		rl.on('line', (line) => {
 
-			if (line.search(REGEX_KUBE_CLUSTER_NAME_UPPER) > -1) {
-				//add service vars above or below
-				context.deploymentServicesEnv.forEach(function (service) {
-					//should look like this: CONVERSATION: "{{form.pipeline.parameters.conversation}}"
-					toolchainFileString += (whitespace10 +
-						service.scaffolderName.toUpperCase() + ": \"{{form.pipeline.parameters." + service.scaffolderName + "}}\"\n");
-				})
-			}
-			else if (line.search(REGEX_KUBE_CLUSTER_NAME_LOWER) > -1) {
-				//add form params above or below
+// 			if (line.search(REGEX_KUBE_CLUSTER_NAME_UPPER) > -1) {
+// 				//add service vars above or below
+// 				context.deploymentServicesEnv.forEach(function (service) {
+// 					//should look like this: CONVERSATION: "{{form.pipeline.parameters.conversation}}"
+// 					toolchainFileString += (whitespace10 +
+// 						service.scaffolderName.toUpperCase() + ": \"{{form.pipeline.parameters." + service.scaffolderName + "}}\"\n");
+// 				})
+// 			}
+// 			else if (line.search(REGEX_KUBE_CLUSTER_NAME_LOWER) > -1) {
+// 				//add form params above or below
 
-				context.deploymentServicesEnv.forEach(function (service) {
-					//should look like this: conversation: "{{conversation}}"
-					toolchainFileString += (whitespace6 +
-						service.scaffolderName + ": \"{{" + service.scaffolderName + "}}\"\n");
-				})
+// 				context.deploymentServicesEnv.forEach(function (service) {
+// 					//should look like this: conversation: "{{conversation}}"
+// 					toolchainFileString += (whitespace6 +
+// 						service.scaffolderName + ": \"{{" + service.scaffolderName + "}}\"\n");
+// 				})
 
-			}
-			toolchainFileString += `${line}\n`;
+// 			}
+// 			toolchainFileString += `${line}\n`;
 
 
-		}).on('close', () => {
-			if (promiseIsRejected) { return; }
-			fs.writeFile(toolchainFilePath, toolchainFileString, (err) => {
-				if (err) {
-					logger.error('failed to write updated toolchain.yml to filesystem: ' + err.message);
-					reject(err);
-				} else {
-					logger.info('finished updating toolchain.yml and wrote to filesystem');
-					resolve();
-				}
-			});
-		});
-	})
-}
+// 		}).on('close', () => {
+// 			if (promiseIsRejected) { return; }
+// 			fs.writeFile(toolchainFilePath, toolchainFileString, (err) => {
+// 				if (err) {
+// 					logger.error('failed to write updated toolchain.yml to filesystem: ' + err.message);
+// 					reject(err);
+// 				} else {
+// 					logger.info('finished updating toolchain.yml and wrote to filesystem');
+// 					resolve();
+// 				}
+// 			});
+// 		});
+// 	})
+// }
 
 // add secretKeyRefs to kube_deploy.sh helm commands
 function addServicesKeysToKubeDeployAsync(args) {
@@ -405,7 +405,8 @@ function addServicesKeysToKubeDeployAsync(args) {
 			if (line.search(REGEX_HELM_UPGRADE) > -1) {
 				let str = '';
 				context.deploymentServicesEnv.forEach(function (service) {
-					str += ",services." + service.scaffolderName + ".secretKeyRef=${" + service.scaffolderName.toUpperCase() + "}";
+					// str += ",services." + service.scaffolderName + ".secretKeyRef=${" + service.scaffolderName.toUpperCase() + "}";
+					str += ",services." + service.scaffolderName + ".secretKeyRef=" + service.valueFrom.secretKeyRef ;
 				})
 				kubeDeployFileString += `${line}` + str + "\n";
 			}
@@ -447,21 +448,22 @@ function generateSecretRefsValues(services) {
 	services.forEach((serviceEntry) => {
 		servicesEnvString +=
 			`  ${serviceEntry.scaffolderName}:\n` +
-			`    secretKeyRef: \${${serviceEntry.scaffolderName.toUpperCase()}}\n`;
+			// `    secretKeyRef: \${${serviceEntry.scaffolderName.toUpperCase()}}\n`;
+			`    secretKeyRef: ${serviceEntry.valueFrom.secretKeyRef.key}\n`;
 	});
 	return servicesEnvString;
 }
 
-function generateServiceProperties(services) {
-	let servicesEnvString = '';
-	services.forEach((serviceEntry) => {
-		servicesEnvString +=
-			`  - name: ` + serviceEntry.scaffolderName.toUpperCase() + `\n` +
-			`    value: \${` + serviceEntry.scaffolderName.toUpperCase() + `}\n` +
-			`    type: text\n`
-	});
-	return servicesEnvString;
-}
+// function generateServiceProperties(services) {
+// 	let servicesEnvString = '';
+// 	services.forEach((serviceEntry) => {
+// 		servicesEnvString +=
+// 			`  - name: ` + serviceEntry.scaffolderName.toUpperCase() + `\n` +
+// 			`    value: \${` + serviceEntry.scaffolderName.toUpperCase() + `}\n` +
+// 			`    type: text\n`
+// 	});
+// 	return servicesEnvString;
+// }
 
 module.exports = {
 	getSpringServiceInfo: getSpringServiceInfo,
@@ -470,6 +472,6 @@ module.exports = {
 	addServicesEnvToHelmChartAsync: addServicesEnvToHelmChartAsync,
 	addServicesToPipelineYamlAsync: addServicesToPipelineYamlAsync,
 	addServicesEnvToValuesAsync: addServicesEnvToValuesAsync,
-	addServicesEnvToToolchainAsync: addServicesEnvToToolchainAsync,
+	// addServicesEnvToToolchainAsync: addServicesEnvToToolchainAsync,
 	addServicesKeysToKubeDeployAsync: addServicesKeysToKubeDeployAsync
 };

--- a/test/app-services-test.js
+++ b/test/app-services-test.js
@@ -32,7 +32,7 @@ serviceKeys.forEach(serviceKey => {
 	let scaffolderKey = scaffolderMapping[serviceKey];
 	let service = Array.isArray(optionsBluemix[scaffolderKey]) ? optionsBluemix[scaffolderKey][0] : optionsBluemix[scaffolderKey];
 	if (service && service.hasOwnProperty('serviceInfo')) {
-		keyRefNames.push("${" + scaffolderKey.toUpperCase() + "}");
+		keyRefNames.push(`${service.serviceInfo.name}`);
 	}
 });
 


### PR DESCRIPTION
Since deployment assets are generated at deployment time and these assets are not stored in the static repos, we no longer need mustache tags for service instance names and secretKeyRefs. This PR changes mustache tags to instance names and removes the instance names as form parameters/env vars in toolchain/pipeline yamls